### PR TITLE
fix: update service before subscribe callback

### DIFF
--- a/clients/naming_client/host_reator.go
+++ b/clients/naming_client/host_reator.go
@@ -71,6 +71,8 @@ func (hr *HostReactor) ProcessServiceJson(result string) {
 			return
 		}
 	}
+	hr.updateTimeMap.Set(cacheKey, uint64(utils.CurrentMillis()))
+	hr.serviceInfoMap.Set(cacheKey, *service)
 	if !ok || ok && !reflect.DeepEqual(service.Hosts, oldDomain.(model.Service).Hosts) {
 		if !ok {
 			log.Println("[INFO] service not found in cache " + cacheKey)
@@ -80,8 +82,6 @@ func (hr *HostReactor) ProcessServiceJson(result string) {
 		cache.WriteServicesToFile(*service, hr.cacheDir)
 		hr.subCallback.ServiceChanged(service)
 	}
-	hr.updateTimeMap.Set(cacheKey, uint64(utils.CurrentMillis()))
-	hr.serviceInfoMap.Set(cacheKey, *service)
 }
 
 func (hr *HostReactor) GetServiceInfo(serviceName string, clusters string) model.Service {


### PR DESCRIPTION
it is a bug, if I call naming.Subscribe( callback ) ，and in the callback I call GetService will always get last old data.

e.g
```go
func(services []model.SubscribeService, err error){
    for _, service := range services {
        // ps this updatedService is old 
         updatedService, err := np.namingClient.GetService(vo.GetServiceParam{
		[]string{service.clusterName},
		service.serviceName,
	})
        
    } 
   
}
```

 because notify service changed is always before set `serviceInfoMap`