### PR TITLE
Update push_receiver.go

### DIFF
--- a/clients/naming_client/push_receiver.go
+++ b/clients/naming_client/push_receiver.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"net"
-	"os"
+	// "os"
 	"strconv"
 	"time"
 )


### PR DESCRIPTION
"os.Exit(1)" 方法注释后，"os"引入未删除