### PR TITLE
服务注册时给 Metadata 设置默认值

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -62,6 +62,9 @@ func (sc *NamingClient) RegisterInstance(param vo.RegisterInstanceParam) (bool, 
 	if param.GroupName == "" {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
+	if param.Metadata == nil {
+		param.Metadata = make(map[string]string)
+	}
 	instance := model.Instance{
 		Ip:          param.Ip,
 		Port:        param.Port,


### PR DESCRIPTION
注册服务时如果没有设置元数据，默认值将会是 nil，这会导致 Spring boot 网关启动时报错。

我注册服务时的配置：
<img width="972" alt="C04B314E-8629-4B65-84BE-7A359C01A5A8" src="https://user-images.githubusercontent.com/32380374/86201564-79204a00-bb92-11ea-9e6e-d76f814e89b0.png">

网关的报错：
<img width="1675" alt="E954423D-03F1-4173-9871-A6ECF1226741" src="https://user-images.githubusercontent.com/32380374/86201593-8dfcdd80-bb92-11ea-8bf0-8b619732238d.png">
<img width="1677" alt="61FC6BFB-0F48-4BB6-A78E-6AB208DC440E" src="https://user-images.githubusercontent.com/32380374/86201601-92c19180-bb92-11ea-9b8d-294223546f10.png">
