### PR TITLE
Count the number of listeners using Concurrentmap.count

### DIFF
--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -336,7 +336,7 @@ func delayScheduler(t *time.Timer, delay time.Duration, taskId string, execute f
 //Listen for the configuration executor
 func listenConfigExecutor() func() error {
 	return func() error {
-		listenerSize := len(cacheMap.Keys())
+		listenerSize := cacheMap.Count()
 		taskCount := int(math.Ceil(float64(listenerSize) / float64(perTaskConfigSize)))
 
 		if taskCount > currentTaskCount {


### PR DESCRIPTION
优化使用Concurrentmap.count计算监听者数量。
fix:https://github.com/nacos-group/nacos-sdk-go/issues/157