### PR TITLE
Fix server config scheme missing

### DIFF
--- a/common/nacos_server/nacos_server.go
+++ b/common/nacos_server/nacos_server.go
@@ -276,7 +276,7 @@ func (server *NacosServer) refreshServerSrvIfNeed() {
 					continue
 				}
 			}
-			servers = append(servers, constant.ServerConfig{IpAddr: splitLine[0], Port: uint64(port), ContextPath: constant.WEB_CONTEXT})
+			servers = append(servers, constant.ServerConfig{Scheme: constant.DEFAULT_SERVER_SCHEME, IpAddr: splitLine[0], Port: uint64(port), ContextPath: constant.WEB_CONTEXT})
 		}
 	}
 	if len(servers) > 0 {


### PR DESCRIPTION
Fix: missing udpPort when send beat info & lose server config scheme when called refreshServerIfNeed