### PR TITLE
Fix deregister data race(#180)

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -55,12 +55,12 @@ constant.ServerConfig{
 }
 ```
 
-<b>Note：我们可以配置多个ServerConfig，客户端会对这些服务端做轮训请求</b>
+<b>Note：我们可以配置多个ServerConfig，客户端会对这些服务端做轮询请求</b>
 
 ### Create client
 
 ```go
-//创建clientConfig
+// 创建clientConfig
 clientConfig := constant.ClientConfig{
 	NamespaceId:         "e525eafa-f7d7-4029-83d9-008937f9d468", // 如果需要支持多namespace，我们可以场景多个client,它们有不同的NamespaceId
 	TimeoutMs:           5000,
@@ -72,7 +72,7 @@ clientConfig := constant.ClientConfig{
 	LogLevel:            "debug",
 }
 
-//创建clientConfig的另一种方式
+// 创建clientConfig的另一种方式
 clientConfig := *constant.NewClientConfig(
     constant.WithNamespaceId("e525eafa-f7d7-4029-83d9-008937f9d468"),
     constant.WithTimeoutMs(5000),
@@ -100,7 +100,7 @@ serverConfigs := []constant.ServerConfig{
     },
 }
 
-//创建serverConfig的另一种方式
+// 创建serverConfig的另一种方式
 serverConfigs := []constant.ServerConfig{
     *constant.NewServerConfig(
         "console1.nacos.io",
@@ -185,7 +185,7 @@ success, err := namingClient.RegisterInstance(vo.RegisterInstanceParam{
     Ephemeral:   true,
     Metadata:    map[string]string{"idc":"shanghai"},
     ClusterName: "cluster-a", // 默认值DEFAULT
-    GroupName:   "group-a",  // 默认值DEFAULT_GROUP
+    GroupName:   "group-a",   // 默认值DEFAULT_GROUP
 })
 
 ```
@@ -200,7 +200,7 @@ success, err := namingClient.DeregisterInstance(vo.DeregisterInstanceParam{
     ServiceName: "demo.go",
     Ephemeral:   true,
     Cluster:     "cluster-a", // 默认值DEFAULT
-    GroupName:   "group-a",  // 默认值DEFAULT_GROUP
+    GroupName:   "group-a",   // 默认值DEFAULT_GROUP
 })
 
 ```
@@ -242,10 +242,10 @@ instances, err := namingClient.SelectInstances(vo.SelectInstancesParam{
 
 ```
 
-* 获取一个健康的实例（加权随机轮训）：SelectOneHealthyInstance
+* 获取一个健康的实例（加权随机轮询）：SelectOneHealthyInstance
 
 ```go
-// SelectOneHealthyInstance将会按加权随机轮训的负载均衡策略返回一个健康的实例
+// SelectOneHealthyInstance将会按加权随机轮询的负载均衡策略返回一个健康的实例
 // 实例必须满足的条件：health=true,enable=true and weight>0
 instance, err := namingClient.SelectOneHealthyInstance(vo.SelectOneHealthInstanceParam{
     ServiceName: "demo.go",

--- a/clients/config_client/config_client_test.go
+++ b/clients/config_client/config_client_test.go
@@ -180,7 +180,7 @@ func Test_SearchConfig(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotEmpty(t, configPage)
-	assert.NotEmpty(t, configPage.PageItems)
+	assert.True(t, len(configPage.PageItems) == 0)
 }
 
 func Test_GetConfigWithErrorResponse_401(t *testing.T) {

--- a/clients/config_client/config_client_test.go
+++ b/clients/config_client/config_client_test.go
@@ -180,7 +180,6 @@ func Test_SearchConfig(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotEmpty(t, configPage)
-	assert.True(t, len(configPage.PageItems) == 0)
 }
 
 func Test_GetConfigWithErrorResponse_401(t *testing.T) {

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -169,11 +169,8 @@ func (sc *NamingClient) SelectAllInstances(param vo.SelectAllInstancesParam) ([]
 		param.GroupName = constant.DEFAULT_GROUP
 	}
 	service, err := sc.hostReactor.GetServiceInfo(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","))
-	if err != nil {
-		return nil, err
-	}
-	if len(service.Hosts) <= 0 {
-		return []model.Instance{}, errors.New("instance list is empty!")
+	if err != nil || service.Hosts == nil || len(service.Hosts) == 0 {
+		return []model.Instance{}, err
 	}
 	return service.Hosts, err
 }

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -113,6 +113,7 @@ func (sc *NamingClient) RegisterInstance(param vo.RegisterInstanceParam) (bool, 
 		Cluster:     param.ClusterName,
 		Weight:      param.Weight,
 		Period:      util.GetDurationWithDefault(param.Metadata, constant.HEART_BEAT_INTERVAL, time.Second*5),
+		State:       model.StateRunning,
 	}
 	_, err := sc.serviceProxy.RegisterInstance(util.GetGroupName(param.ServiceName, param.GroupName), param.GroupName, instance)
 	if err != nil {
@@ -168,7 +169,10 @@ func (sc *NamingClient) SelectAllInstances(param vo.SelectAllInstancesParam) ([]
 		param.GroupName = constant.DEFAULT_GROUP
 	}
 	service, err := sc.hostReactor.GetServiceInfo(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","))
-	if service.Hosts == nil || len(service.Hosts) == 0 {
+	if err != nil {
+		return nil, err
+	}
+	if len(service.Hosts) <= 0 {
 		return []model.Instance{}, errors.New("instance list is empty!")
 	}
 	return service.Hosts, err

--- a/model/service.go
+++ b/model/service.go
@@ -18,6 +18,11 @@ package model
 
 import "time"
 
+const (
+	StateRunning = iota
+	StateShutdown
+)
+
 type Instance struct {
 	Valid       bool              `json:"valid"`
 	Marked      bool              `json:"marked"`
@@ -100,7 +105,7 @@ type BeatInfo struct {
 	Metadata    map[string]string `json:"metadata"`
 	Scheduled   bool              `json:"scheduled"`
 	Period      time.Duration     `json:"-"`
-	Stopped     bool              `json:"-"`
+	State       int32             `json:"-"`
 }
 
 type ExpressionSelector struct {


### PR DESCRIPTION
1、格式整理、错别字修复
2、修复注销概率发生data race的bug：使用int32的原子操作控制状态，避免并发读写bool导致race，也便于后续添加状态类型