### PR TITLE
Fix default timeoutms config

### DIFF
--- a/clients/nacos_client/nacos_client.go
+++ b/clients/nacos_client/nacos_client.go
@@ -38,8 +38,7 @@ type NacosClient struct {
 //SetClientConfig is use to set nacos client Config
 func (client *NacosClient) SetClientConfig(config constant.ClientConfig) (err error) {
 	if config.TimeoutMs <= 0 {
-		err = errors.New("[client.SetClientConfig] config.TimeoutMs should > 0")
-		return
+		config.TimeoutMs = 10 * 1000
 	}
 
 	if config.BeatInterval <= 0 {


### PR DESCRIPTION
When users don't set timeoutms config, we should set the default value according the comment of this config.