### PR TITLE
Trigger callback when subscribe service

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -297,10 +297,11 @@ func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
 	}
 
 	sc.subCallback.AddCallbackFuncs(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","), &param.SubscribeCallback)
-	_, err := sc.GetService(serviceParam)
+	svc, err := sc.GetService(serviceParam)
 	if err != nil {
 		return err
 	}
+	sc.subCallback.ServiceChanged(&svc)
 	return nil
 }
 

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -301,7 +301,9 @@ func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
 	if err != nil {
 		return err
 	}
-	sc.subCallback.ServiceChanged(&svc)
+	if !sc.hostReactor.serviceProxy.clientConfig.NotLoadCacheAtStart {
+		sc.subCallback.ServiceChanged(&svc)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently, when the service information is cached in the local file, the callback function will not be triggered when we call the subscribe method. So we should trigger a callback when subscribe is called.