### PR TITLE
refine SetClientConfig

### DIFF
--- a/clients/client_factory.go
+++ b/clients/client_factory.go
@@ -84,15 +84,9 @@ func setConfig(param vo.NacosClientParam) (iClient nacos_client.INacosClient, er
 	client := &nacos_client.NacosClient{}
 	if param.ClientConfig == nil {
 		// default clientConfig
-		_ = client.SetClientConfig(constant.ClientConfig{
-			TimeoutMs:    10 * 1000,
-			BeatInterval: 5 * 1000,
-		})
+		client.SetClientConfig(constant.ClientConfig{})
 	} else {
-		err = client.SetClientConfig(*param.ClientConfig)
-		if err != nil {
-			return nil, err
-		}
+		client.SetClientConfig(*param.ClientConfig)
 	}
 
 	if len(param.ServerConfigs) == 0 {


### PR DESCRIPTION
refine SetClientConfig
Timeoutms and BeatInterval are configured by default in SetClientConfig func.