### PR TITLE
fix: 当服务名称为空时导致 nacos 服务异常的问题

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -89,6 +89,9 @@ func NewNamingClient(nc nacos_client.INacosClient) (NamingClient, error) {
 
 // 注册服务实例
 func (sc *NamingClient) RegisterInstance(param vo.RegisterInstanceParam) (bool, error) {
+	if param.ServiceName == "" {
+		return false, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}


### PR DESCRIPTION
#201 
当 nacos 服务端版本低于 1.3.x 时,空服务名会导致 nacos 实例异常. 服务端版本大于 1.3.x 时修复了这个问题,所以在客户端也加上判断
![image](https://user-images.githubusercontent.com/35397691/112974627-4341dd80-9185-11eb-9a29-e7a8749a3bac.png)
![image](https://user-images.githubusercontent.com/35397691/112974722-594f9e00-9185-11eb-84fe-6f9ca558c2c8.png)
