### PR TITLE
fix nil pointer exception bug

### DIFF
--- a/clients/naming_client/push_receiver.go
+++ b/clients/naming_client/push_receiver.go
@@ -91,7 +91,11 @@ func (us *PushReceiver) startServer() {
 	}
 
 	go func() {
-		defer conn.Close()
+		defer func() {
+			if conn != nil {
+				conn.Close()
+			}
+		}()
 		for {
 			us.handleClient(conn)
 		}


### PR DESCRIPTION
When connection has not been established, close it directly would cause nil pointer exception.