### PR TITLE
bugfix: redoRegisterEachService function to get servicename and groupname error

### DIFF
--- a/clients/naming_client/naming_grpc/connection_event_listener.go
+++ b/clients/naming_client/naming_grpc/connection_event_listener.go
@@ -69,8 +69,8 @@ func (c *ConnectionEventListener) redoSubscribe() {
 func (c *ConnectionEventListener) redoRegisterEachService() {
 	for k, v := range c.registeredInstanceCached.Items() {
 		info := strings.Split(k, constant.SERVICE_INFO_SPLITER)
-		serviceName := info[0]
-		groupName := info[1]
+		serviceName := info[1]
+		groupName := info[0]
 		instances, ok := v.([]model.Instance)
 		if !ok {
 			logger.Warnf("redo register service:%s faild,instances type not is []model.instance", info[0])


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
redoRegisterEachService will cause servicename and groupname to swap

https://github.com/alibaba/nacos/issues/6232

Which issue(s) this PR fixes:
Fixes #276

Special notes for your reviewer:
@sanxun0325

Does this PR introduce a user-facing change?

> No

Additional documentation e.g., usage docs, etc.:
> No
