### PR TITLE
fix leak of goroutine

### DIFF
--- a/clients/cache/concurrent_map.go
+++ b/clients/cache/concurrent_map.go
@@ -197,9 +197,9 @@ func (m ConcurrentMap) IterBuffered() <-chan Tuple {
 // It returns once the size of each buffered channel is determined,
 // before all the channels are populated using goroutines.
 func snapshot(m ConcurrentMap) (chans []chan Tuple) {
-	chans = make([]chan Tuple, SHARD_COUNT)
+	chans = make([]chan Tuple, len(m))
 	wg := sync.WaitGroup{}
-	wg.Add(SHARD_COUNT)
+	wg.Add(len(m))
 	// Foreach shard.
 	for index, shard := range m {
 		go func(index int, shard *ConcurrentMapShared) {


### PR DESCRIPTION
ConcurrentMap 数量并不一定恰好为SHARD_COUNT，如果不是SHARD_COUNT的情况下，会导致goroutine一直卡在wait上面不会退出，造成goroutine泄漏