### PR TITLE
support tls

### DIFF
--- a/clients/client_factory.go
+++ b/clients/client_factory.go
@@ -111,7 +111,9 @@ func setConfig(param vo.NacosClientParam) (iClient nacos_client.INacosClient, er
 	}
 
 	if _, _err := client.GetHttpAgent(); _err != nil {
-		_ = client.SetHttpAgent(&http_agent.HttpAgent{})
+		if clientCfg, err := client.GetClientConfig(); err == nil {
+			_ = client.SetHttpAgent(&http_agent.HttpAgent{TlsConfig: clientCfg.TLSCfg})
+		}
 	}
 	iClient = client
 	return

--- a/common/constant/client_config_options.go
+++ b/common/constant/client_config_options.go
@@ -171,3 +171,9 @@ func WithLogRollingConfig(rollingConfig *ClientLogRollingConfig) ClientOption {
 		config.LogRollingConfig = rollingConfig
 	}
 }
+
+func WithTLS(tlsCfg TLSConfig) ClientOption {
+	return func(config *ClientConfig) {
+		config.TLSCfg = tlsCfg
+	}
+}

--- a/common/constant/config.go
+++ b/common/constant/config.go
@@ -48,6 +48,7 @@ type ClientConfig struct {
 	ContextPath          string                   // the nacos server contextpath
 	LogSampling          *ClientLogSamplingConfig // the sampling config of log
 	LogRollingConfig     *ClientLogRollingConfig  // log rolling config
+	TLSCfg               TLSConfig                // tls Config
 }
 
 type ClientLogSamplingConfig struct {
@@ -81,4 +82,12 @@ type ClientLogRollingConfig struct {
 	// Compress determines if the rotated log files should be compressed
 	// using gzip. The default is not to perform compression.
 	Compress bool
+}
+
+type TLSConfig struct {
+	Enable             bool   // enable tls
+	CaFile             string // clients use when verifying server certificates
+	CertFile           string // server use when verifying client certificates
+	KeyFile            string // server use when verifying client certificates
+	ServerNameOverride string // serverNameOverride is for testing only
 }

--- a/common/constant/const.go
+++ b/common/constant/const.go
@@ -77,6 +77,7 @@ const (
 	NAMING_INSTANCE_ID_SPLITTER = "#"
 	DefaultClientErrorCode      = "SDK.NacosError"
 	DEFAULT_SERVER_SCHEME       = "http"
+	HTTPS_SERVER_SCHEME         = "https"
 	LABEL_SOURCE                = "source"
 	LABEL_SOURCE_SDK            = "sdk"
 	LABEL_MODULE                = "module"
@@ -93,4 +94,5 @@ const (
 	EX_CONFIG_INFO              = "exConfigInfo"
 	CHARSET_KEY                 = "charset"
 	LOG_FILE_NAME               = "nacos-sdk.log"
+	HTTPS_SERVER_PORT           = 443
 )

--- a/common/constant/server_tls_options.go
+++ b/common/constant/server_tls_options.go
@@ -13,31 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package http_agent
 
-import (
-	"net/http"
-	"strings"
-	"time"
+package constant
 
-	"github.com/nacos-group/nacos-sdk-go/v2/util"
-)
+var SkipVerifyConfig = TLSConfig{Enable: true}
 
-func post(client *http.Client, path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
-	client.Timeout = time.Millisecond * time.Duration(timeoutMs)
-
-	body := util.GetUrlFormedMap(params)
-	request, errNew := http.NewRequest(http.MethodPost, path, strings.NewReader(body))
-	if errNew != nil {
-		err = errNew
-		return
+func NewTLSConfig(opts ...TLSOption) *TLSConfig {
+	tlsConfig := TLSConfig{Enable: true}
+	for _, opt := range opts {
+		opt(&tlsConfig)
 	}
-	request.Header = header
-	resp, errDo := client.Do(request)
-	if errDo != nil {
-		err = errDo
-	} else {
-		response = resp
+	return &tlsConfig
+}
+
+type TLSOption func(*TLSConfig)
+
+func WithCA(caFile, serverNameOverride string) TLSOption {
+	return func(tc *TLSConfig) {
+		tc.CaFile = caFile
+		tc.ServerNameOverride = serverNameOverride
 	}
-	return
+}
+
+func WithCertificate(certFile, keyFile string) TLSOption {
+	return func(tc *TLSConfig) {
+		tc.CertFile = certFile
+		tc.KeyFile = keyFile
+	}
 }

--- a/common/constant/server_tls_options_test.go
+++ b/common/constant/server_tls_options_test.go
@@ -1,0 +1,54 @@
+package constant
+
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTLSConfigWithOptions(t *testing.T) {
+	t.Run("TestNoOption", func(t *testing.T) {
+		cfg := SkipVerifyConfig
+		assert.Equal(t, "", cfg.CaFile)
+		assert.Equal(t, "", cfg.CertFile)
+		assert.Equal(t, "", cfg.KeyFile)
+		assert.Equal(t, "", cfg.ServerNameOverride)
+	})
+
+	t.Run("TestCAOption", func(t *testing.T) {
+		cfg := NewTLSConfig(
+			WithCA("ca", "host"),
+		)
+		assert.Equal(t, "ca", cfg.CaFile)
+		assert.Equal(t, "", cfg.CertFile)
+		assert.Equal(t, "", cfg.KeyFile)
+		assert.Equal(t, "host", cfg.ServerNameOverride)
+	})
+
+	t.Run("TestCertOption", func(t *testing.T) {
+		cfg := NewTLSConfig(
+			WithCA("ca", "host"),
+			WithCertificate("cert", "key"),
+		)
+		assert.Equal(t, "ca", cfg.CaFile)
+		assert.Equal(t, "cert", cfg.CertFile)
+		assert.Equal(t, "key", cfg.KeyFile)
+		assert.Equal(t, "host", cfg.ServerNameOverride)
+	})
+}

--- a/common/http_agent/delete.go
+++ b/common/http_agent/delete.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-func delete(path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
+func delete(client *http.Client, path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
 	if !strings.HasSuffix(path, "?") {
 		path = path + "?"
 	}
@@ -32,7 +32,6 @@ func delete(path string, header http.Header, timeoutMs uint64, params map[string
 	if strings.HasSuffix(path, "&") {
 		path = path[:len(path)-1]
 	}
-	client := http.Client{}
 	client.Timeout = time.Millisecond * time.Duration(timeoutMs)
 	request, errNew := http.NewRequest(http.MethodDelete, path, nil)
 	if errNew != nil {

--- a/common/http_agent/get.go
+++ b/common/http_agent/get.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-func get(path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
+func get(client *http.Client, path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
 	if !strings.HasSuffix(path, "?") {
 		path = path + "?"
 	}
@@ -34,7 +34,6 @@ func get(path string, header http.Header, timeoutMs uint64, params map[string]st
 		path = path[:len(path)-1]
 	}
 
-	client := http.Client{}
 	client.Timeout = time.Millisecond * time.Duration(timeoutMs)
 	request, errNew := http.NewRequest(http.MethodGet, path, nil)
 	if errNew != nil {

--- a/common/http_agent/put.go
+++ b/common/http_agent/put.go
@@ -22,8 +22,7 @@ import (
 	"time"
 )
 
-func put(path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
-	client := http.Client{}
+func put(client *http.Client, path string, header http.Header, timeoutMs uint64, params map[string]string) (response *http.Response, err error) {
 	client.Timeout = time.Millisecond * time.Duration(timeoutMs)
 	var body string
 	for key, value := range params {

--- a/common/tls/tls.go
+++ b/common/tls/tls.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
+)
+
+// NewTLS returns a config structure is used to configure a TLS client
+func NewTLS(c constant.TLSConfig) (tc *tls.Config, err error) {
+	tc = &tls.Config{}
+	if len(c.CertFile) > 0 && len(c.KeyFile) > 0 {
+		cert, err := certificate(c.CertFile, c.KeyFile)
+		if err != nil {
+			return nil, err
+		}
+		tc.Certificates = []tls.Certificate{*cert}
+	}
+
+	if len(c.CaFile) <= 0 {
+		tc.InsecureSkipVerify = true
+		return tc, nil
+	}
+	if len(c.ServerNameOverride) > 0 {
+		tc.ServerName = c.ServerNameOverride
+	}
+	tc.RootCAs, err = rootCert(c.CaFile)
+	return
+}
+
+func rootCert(caFile string) (*x509.CertPool, error) {
+	b, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+	cp := x509.NewCertPool()
+	if !cp.AppendCertsFromPEM(b) {
+		return nil, fmt.Errorf("credentials: failed to append certificates")
+	}
+	return cp, nil
+}
+
+func certificate(certFile, keyFile string) (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	return &cert, nil
+}

--- a/common/tls/tls_test.go
+++ b/common/tls/tls_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testCaCrt = []byte(`-----BEGIN CERTIFICATE-----
+MIICojCCAYoCCQDbLXd9WTa7rTANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAh3
+ZS1hcy1jYTAeFw0yMTA4MDQxNTE3MTlaFw00ODEyMjAxNTE3MTlaMBMxETAPBgNV
+BAMMCHdlLWFzLWNhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyc0D
+ca+T6zwVnroauoVYQvPEx6R2jxmEgmCEclXegmO0rJ+23nP63nhgDvLN2Yv4olmv
+d+eh1WfsnmqfdtqUcooZQIYZHWw5jWSYygZOwUWzfIclVFcyfkZnP7qTMGjYPn9Y
+hOfdgSIh1c/DXrKFu1VQd9p3DevUD+ImAbxYJW4SMgYvliooPABbFU/sm3ZrHPwb
+Ik8U1KlGHoYtw8KslD0INTfOOEYfQToeZtoAkoajykyteYYbI0kNVYBr2W3AOEXt
+/QQkj/kAa1o8YKrVkufvi90UI/53SnJa0o5TDzXJCAu4jg4Xfpq0tVogFuEamMeI
+f2R4JL77flG41nqN2QIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCOYw0C4wJTbHly
+LRmR7lJiLDkdObVKyQM6UUrbY62h9Fu02vYI9a8sj4xVSr3JKTXWBUwXSDqTUqgr
++9+sWoWxGwHbDINVHSsy2vnZlhGFkRkdWv3qgAPOn1Dc2ZMVzNEXRnmLFc1X2Ir/
+niuk4cqSKwFE4IoJz9CHDDOlJzowimTwD6ReIrJDhi0pEFE6YtBVfRF5XPvz3AyG
+mIFTX9LPRmCBnRi7We9cea+zuFarbjU6qDtf9jDfWANz1Gv6OHf0oM6BoCJ0jp0b
+tJ5yJe4OCybgpb5bMZygBkGWozeQ5I/XzhkswNN0jVXeC3e0UWLscYvsgPVAM1kH
+vZvo/wBG
+-----END CERTIFICATE-----`)
+
+	testClientCrt = []byte(`-----BEGIN CERTIFICATE-----
+MIICozCCAYsCCQDaqEi3maR5ojANBgkqhkiG9w0BAQUFADATMREwDwYDVQQDDAh3
+ZS1hcy1jYTAeFw0yMTA4MDQxNTE4MzFaFw0yMjA4MDQxNTE4MzFaMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALPN
+fcRRVPcinxUhS+Q1pvL6nZk7Gg7vcyoOqdX68R/iG/by/dL/wKbYzi2gyMyNN7Q8
+o1+74inrsS5KMXAuyxrurdudWaoS9eWFzrd9r98+47kxUVwye5R4leT9+NCiI0mp
+HOqEkOFv+X//kkCtCpDVj/XkfZJ+UrJHgAHvL9me/v5yUvLDDgu7/cdGU1tRwGQc
+zabzk8SkvoQjMWaZ+R1eIWfeg9lYFyWQyYJhZkAqlBhlyDHw3FfrfPKjrxsI6uDq
+ACeptHUuMZu6H6EzKDJtnx5DhSrwXTOwEcsOzTl60Hb2wT154CGi+7VbaZDGl6Uf
+ZBkVAiSZvNCDJ0NGa9kCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAqjg4WeFbUcYC
+Ko5R6UNTEYUvLYk45hks/Cmu5Mdqe3tFbPsr3EVdqd+zFJrINQQTlhZx14stJjIO
+b3+eRX7Rldow7AI9Q2dyCQUoWiYmmco//4Mx1jObN2wMUd7tavhwg8RNdps1Yly2
+/l0Vj2OhNDFnApqAiHZ0NGuCW7CLBvuD2XFCPZLCYFv0aQTw/Vr0+hHvNApmFYn0
+4wiveiWUf98KKrp93lbzskAd3OZmoNx4bIo/J2Arcz0KzuliBgXDcGPOb4YLRLgs
+QBhpY/VCGRat52Ys+sm6l/+2Cv+C2mHhn6V4BNVifaZIgOofXwzO4vaQO9sNTZ4f
+qqJ4/s4nDg==
+-----END CERTIFICATE-----`)
+
+	testClientKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAs819xFFU9yKfFSFL5DWm8vqdmTsaDu9zKg6p1frxH+Ib9vL9
+0v/AptjOLaDIzI03tDyjX7viKeuxLkoxcC7LGu6t251ZqhL15YXOt32v3z7juTFR
+XDJ7lHiV5P340KIjSakc6oSQ4W/5f/+SQK0KkNWP9eR9kn5SskeAAe8v2Z7+/nJS
+8sMOC7v9x0ZTW1HAZBzNpvOTxKS+hCMxZpn5HV4hZ96D2VgXJZDJgmFmQCqUGGXI
+MfDcV+t88qOvGwjq4OoAJ6m0dS4xm7ofoTMoMm2fHkOFKvBdM7ARyw7NOXrQdvbB
+PXngIaL7tVtpkMaXpR9kGRUCJJm80IMnQ0Zr2QIDAQABAoIBAFMiakpBSMXT7jY4
+5Pwpin3CPuhAmXXaZSdHDGPx2VdiloeCJrZOpmb+y6XxN6bMjLr7Zpa3KoUzgwLi
+LyWtnR9gyGZIxNKMXcG4MrJInO7eBzDziqjUdqtZbgUpIMhmj2ZZmRMeJFb4DSaP
+prHc0IvTEvMgqKb5XYcs5BUA4OD/ihXvpW7GN4c/+iakJN0UBTI0/P/bTiYkERN8
+ousw8UebrODyUbI20rqL/UO8UyOPIyifFpU29nvn/57Z42TzU+BqdxmJG5VJCR7w
+lvJhA+jkldorHksHm1Z/9qDMj2UIvuPTJoa6L2t1utJRFgE+27QKHQ9Nv7IjbkUr
+gdHO/QECgYEA5TneVmplJ4ARg8JIFYBotArcSj4f+Z2pZ36KO2CMklnnTFy2tAuw
+766yxvZULCU5hr9AwlQwGkqt99o50a8WP4HBGjZ27r6CPODbvZvF7JnsFsD8z178
+H52GNMO626KogDrC6aoJnYPJQAY+wGhR6Gg05goGoiKdUnhBOzKuEfECgYEAyM3O
+TUch0FTBmKGA7IWGRL9bQBpw13UtZOokm5g5zTg+yDsQZ5BZCIgycZf77zQmIpbZ
+TJe8xeFBI8fjfAF+UAfvzwwc4b3dSmD/jUSrv2gcKfCff2wZw8c8sYwbqNpSeX3l
+Y2m7VJj5fw8I2vMOKjzISNKX55qNc8BGUuLiEGkCgYEA1Gb93ccyuhpSoGuLDdlx
+q7sQiv7r9AmiqpK3lfON7iK+T6TtawIWTtHrOK+SKWHI31IiuK7377TZZPvibai2
+jdw2yYpERE9lMPIOy7AnA2lROXhUCfdy2fzGGehwIgqj5kYMzCXSSRGPjvL6fKFt
+nFPLCImrwdsfOgbSMv9wCpECgYA1n2fxEQbBmHCebrp77ug9IZCfnK/3iW4W3cPq
+3QrKd7OkSsmFrnFoKt61oO2BIj7wy7G5l2esvAtmH7Hq4oc1nfj3JHft/ILEowR7
+WBQ5J/claAFfyKFUu7bEfvK/85VEpk8Ebi69V6CAwqYNugxVUSf28m3oRkhx2a2t
+4rKVyQKBgBYWALJLO3YwzpdelzVJiOPatVrphQarUKafsE32u/iBBvJwfpYpkclh
+kJ4wLmJAMU8VAhvfSh6T8z8us9z3znONoUI0z6GzwbjROFRtd2WiffXvgcKfTacu
+q9K53Jum9GDmkbUODa77sWR1zQsdrqSKywcjP/6FYXU9RMDqKUpm
+-----END RSA PRIVATE KEY-----`)
+)
+
+func Test_NewTLS(t *testing.T) {
+	dir, err := ioutil.TempDir("", "tls-test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	defer os.RemoveAll(dir)
+
+	caPath, crtPath, keyPath := filepath.Join(dir, "ca.crt"), filepath.Join(dir, "client.crt"), filepath.Join(dir, "client.key")
+	ioutil.WriteFile(caPath, testCaCrt, 0666)
+	ioutil.WriteFile(crtPath, testClientCrt, 0666)
+	ioutil.WriteFile(keyPath, testClientKey, 0666)
+
+	t.Run("TestNoAuth", func(t *testing.T) {
+		cfg, err := NewTLS(constant.SkipVerifyConfig)
+		assert.Nil(t, err)
+		assert.Equal(t, true, cfg.InsecureSkipVerify)
+		assert.Nil(t, cfg.RootCAs)
+		assert.Nil(t, cfg.Certificates)
+
+	})
+
+	t.Run("TestClientAuth", func(t *testing.T) {
+		cfg, err := NewTLS(*constant.NewTLSConfig(
+			constant.WithCA(caPath, ""),
+		))
+		assert.Nil(t, err)
+		assert.Equal(t, false, cfg.InsecureSkipVerify)
+		assert.NotNil(t, cfg.RootCAs)
+		assert.Nil(t, cfg.Certificates)
+
+	})
+
+	t.Run("TestServerAuth", func(t *testing.T) {
+		cfg, err := NewTLS(*constant.NewTLSConfig(
+			constant.WithCA(caPath, ""),
+			constant.WithCertificate(crtPath, keyPath),
+		))
+		assert.Nil(t, err)
+		assert.Equal(t, false, cfg.InsecureSkipVerify)
+		assert.NotNil(t, cfg.RootCAs)
+		assert.NotNil(t, cfg.Certificates)
+	})
+}


### PR DESCRIPTION
**purpose**
issue #259

**changelog:**
add tls.go to provide tls configuration (also applicable to grpc)

**others:**
after this part is passed, filewatcher can be added to monitor tls file change