### PR TITLE
fix: init NamingClient.INacosClient

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -52,7 +52,7 @@ type Chooser struct {
 
 func NewNamingClient(nc nacos_client.INacosClient) (NamingClient, error) {
 	rand.Seed(time.Now().UnixNano())
-	naming := NamingClient{}
+	naming := NamingClient{INacosClient: nc}
 	clientConfig, err := nc.GetClientConfig()
 	if err != nil {
 		return naming, err


### PR DESCRIPTION
In the master branch, INacosClient in NamingClient is not initialized. We should initialize it as we did in v2.

Ref: https://github.com/nacos-group/nacos-sdk-go/blob/2.0.0/clients/naming_client/naming_client.go#L44