### PR TITLE
client automatically re-registers

### DIFF
--- a/common/remote/rpc/rpc_client.go
+++ b/common/remote/rpc/rpc_client.go
@@ -373,6 +373,12 @@ func (r *RpcClient) sendHealthCheck() bool {
 		return false
 	}
 	if !response.IsSuccess() {
+		// when client request immediately after the nacos server starts, the server may not ready to serve new request
+		// the server will return code 3xx, tell the client to retry after a while
+		// this situation, just return true,because the healthCheck will start again after 5 seconds
+		if response.GetErrorCode() >= 300 && response.GetErrorCode() < 400 {
+			return true
+		}
 		return false
 	}
 	return true

--- a/common/remote/rpc/server_request_handler.go
+++ b/common/remote/rpc/server_request_handler.go
@@ -37,10 +37,10 @@ type ConnectResetRequestHandler struct {
 }
 
 func (c *ConnectResetRequestHandler) RequestReply(request rpc_request.IRequest, rpcClient *RpcClient) rpc_response.IResponse {
-	defer rpcClient.mux.Unlock()
 	connectResetRequest, ok := request.(*rpc_request.ConnectResetRequest)
 	if ok {
 		rpcClient.mux.Lock()
+		defer rpcClient.mux.Unlock()
 		if rpcClient.IsRunning() {
 			if connectResetRequest.ServerIp != "" {
 				serverPortNum, err := strconv.Atoi(connectResetRequest.ServerPort)


### PR DESCRIPTION
this pull request solved the issue #325 and fix a code bug when using lock

the cause of issue #325 is:
when the nacos server startup, it need a while to get ready to serve request.  if a request going to the server in this period, the server whill return 3xx.  this cause the client healthCheck failed and cause the client get a connection to the server failed.