### PR TITLE
fix reconnect can't subscribe problem.

### DIFF
--- a/clients/naming_client/naming_grpc/connection_event_listener.go
+++ b/clients/naming_client/naming_grpc/connection_event_listener.go
@@ -54,15 +54,18 @@ func (c *ConnectionEventListener) redoSubscribe() {
 	for _, key := range c.subscribes.Keys() {
 		info := strings.Split(key, constant.SERVICE_INFO_SPLITER)
 		var err error
+		var service model.Service
 		if len(info) > 2 {
-			_, err = c.clientProxy.Subscribe(info[0], info[1], info[2])
+			service, err = c.clientProxy.Subscribe(info[0], info[1], info[2])
 		} else {
-			_, err = c.clientProxy.Subscribe(info[0], info[1], "")
+			service, err = c.clientProxy.Subscribe(info[0], info[1], "")
 		}
 
 		if err != nil {
 			logger.Warnf("redo subscribe service:%s faild:%+v", info[0], err)
+			return
 		}
+		c.clientProxy.serviceInfoHolder.ProcessService(&service)
 	}
 }
 

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy.go
@@ -143,18 +143,18 @@ func (proxy *NamingGrpcProxy) QueryInstancesOfService(serviceName, groupName, cl
 }
 
 func (proxy *NamingGrpcProxy) Subscribe(serviceName, groupName string, clusters string) (model.Service, error) {
+	proxy.eventListener.CacheSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
 	response, err := proxy.requestToServer(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName,
 		groupName, clusters, true))
 	if err != nil {
 		return model.Service{}, err
 	}
-	proxy.eventListener.CacheSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
 	subscribeServiceResponse := response.(*rpc_response.SubscribeServiceResponse)
 	return subscribeServiceResponse.ServiceInfo, nil
 }
 
 func (proxy *NamingGrpcProxy) Unsubscribe(serviceName, groupName, clusters string) {
+	proxy.eventListener.RemoveSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
 	proxy.requestToServer(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName,
 		clusters, false))
-	proxy.eventListener.RemoveSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
 }


### PR DESCRIPTION
If send rpc request failed, it won't cache subscribe info.  when reconnect, it's won't resubscribe again.

So cache subscribe info firstly, then send rpc request.