### PR TITLE
when disconnect, sleep 1 second to avoid flush too many logs.

### DIFF
--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -165,8 +165,7 @@ func (c *GrpcClient) bindBiRequestStream(streamClient nacos_grpc_service.BiReque
 						}
 					} else {
 						logger.Infof("%s received error event, isRunning:%v, isAbandon=%v, error=%+v", grpcConn.getConnectionId(), running, abandon, err)
-						after := time.After(time.Second)
-						<-after
+						<-time.After(time.Second)
 					}
 				} else {
 					c.handleServerRequest(payload, grpcConn)

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -165,6 +165,7 @@ func (c *GrpcClient) bindBiRequestStream(streamClient nacos_grpc_service.BiReque
 						}
 					} else {
 						logger.Infof("%s Ignore event,isRunning:%v,isAbandon=%v", grpcConn.getConnectionId(), running, abandon)
+						time.Sleep(time.Second)
 					}
 
 				} else {

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -158,16 +158,15 @@ func (c *GrpcClient) bindBiRequestStream(streamClient nacos_grpc_service.BiReque
 						if err == io.EOF {
 							logger.Infof("%s Request stream onCompleted, switch server", grpcConn.getConnectionId())
 						} else {
-							logger.Errorf("%s Request stream error, switch server,error=%+v", grpcConn.getConnectionId(), err)
+							logger.Errorf("%s Request stream error, switch server, error=%+v", grpcConn.getConnectionId(), err)
 						}
 						if atomic.CompareAndSwapInt32((*int32)(&c.rpcClientStatus), int32(RUNNING), int32(UNHEALTHY)) {
 							c.switchServerAsync(ServerInfo{}, false)
 						}
 					} else {
-						logger.Infof("%s Ignore event,isRunning:%v,isAbandon=%v", grpcConn.getConnectionId(), running, abandon)
+						logger.Infof("%s received error event, isRunning:%v, isAbandon=%v, error=%+v", grpcConn.getConnectionId(), running, abandon)
 						time.Sleep(time.Second)
 					}
-
 				} else {
 					c.handleServerRequest(payload, grpcConn)
 				}

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -164,7 +164,7 @@ func (c *GrpcClient) bindBiRequestStream(streamClient nacos_grpc_service.BiReque
 							c.switchServerAsync(ServerInfo{}, false)
 						}
 					} else {
-						logger.Infof("%s received error event, isRunning:%v, isAbandon=%v, error=%+v", grpcConn.getConnectionId(), running, abandon)
+						logger.Infof("%s received error event, isRunning:%v, isAbandon=%v, error=%+v", grpcConn.getConnectionId(), running, abandon, err)
 						time.Sleep(time.Second)
 					}
 				} else {

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -165,7 +165,8 @@ func (c *GrpcClient) bindBiRequestStream(streamClient nacos_grpc_service.BiReque
 						}
 					} else {
 						logger.Infof("%s received error event, isRunning:%v, isAbandon=%v, error=%+v", grpcConn.getConnectionId(), running, abandon, err)
-						time.Sleep(time.Second)
+						after := time.After(time.Second)
+						<-after
 					}
 				} else {
 					c.handleServerRequest(payload, grpcConn)


### PR DESCRIPTION
when disconnect with server, `streamClient.Recv()` can't sync, it will return error immediately.
So here sleep 1ms.