### PR TITLE
Fix connection still after new connection established.

### DIFF
--- a/common/remote/rpc/grpc_connection.go
+++ b/common/remote/rpc/grpc_connection.go
@@ -75,6 +75,7 @@ func (g *GrpcConnection) request(request rpc_request.IRequest, timeoutMills int6
 }
 
 func (g *GrpcConnection) close() {
+	g.Connection.close()
 	g.streamCloseChan <- struct{}{}
 }
 


### PR DESCRIPTION
At server side, it can send connetResetRequest to make client connect to another server manually. 
But now, after the new connection established, the old connection still exist.