### PR TITLE
support resubscribe automatically.

### DIFF
--- a/clients/naming_client/naming_cache/service_info_holder.go
+++ b/clients/naming_client/naming_cache/service_info_holder.go
@@ -31,7 +31,7 @@ type ServiceInfoHolder struct {
 	updateCacheWhenEmpty bool
 	cacheDir             string
 	notLoadCacheAtStart  bool
-	subCallback          *SubscribeCallback
+	SubCallback          *SubscribeCallback
 	UpdateTimeMap        cache.ConcurrentMap
 }
 
@@ -41,7 +41,7 @@ func NewServiceInfoHolder(namespace, cacheDir string, updateCacheWhenEmpty, notL
 		updateCacheWhenEmpty: updateCacheWhenEmpty,
 		notLoadCacheAtStart:  notLoadCacheAtStart,
 		cacheDir:             cacheDir,
-		subCallback:          NewSubscribeCallback(),
+		SubCallback:          NewSubscribeCallback(),
 		UpdateTimeMap:        cache.NewConcurrentMap(),
 		ServiceInfoMap:       cache.NewConcurrentMap(),
 	}
@@ -89,7 +89,7 @@ func (s *ServiceInfoHolder) ProcessService(service *model.Service) {
 			logger.Info("service key:%s was updated to:%s", cacheKey, util.ToJsonString(service))
 		}
 		cache.WriteServicesToFile(*service, s.cacheDir)
-		s.subCallback.ServiceChanged(service)
+		s.SubCallback.ServiceChanged(service)
 	}
 }
 
@@ -104,11 +104,11 @@ func (s *ServiceInfoHolder) GetServiceInfo(serviceName, groupName, clusters stri
 }
 
 func (s *ServiceInfoHolder) RegisterCallback(serviceName string, clusters string, callbackFunc *func(services []model.Instance, err error)) {
-	s.subCallback.AddCallbackFunc(serviceName, clusters, callbackFunc)
+	s.SubCallback.AddCallbackFunc(serviceName, clusters, callbackFunc)
 }
 
 func (s *ServiceInfoHolder) DeregisterCallback(serviceName string, clusters string, callbackFunc *func(services []model.Instance, err error)) {
-	s.subCallback.RemoveCallbackFunc(serviceName, clusters, callbackFunc)
+	s.SubCallback.RemoveCallbackFunc(serviceName, clusters, callbackFunc)
 }
 
 func (s *ServiceInfoHolder) StopUpdateIfContain(serviceName, clusters string) {
@@ -117,5 +117,5 @@ func (s *ServiceInfoHolder) StopUpdateIfContain(serviceName, clusters string) {
 }
 
 func (s *ServiceInfoHolder) IsSubscribed(serviceName, clusters string) bool {
-	return s.subCallback.IsSubscribed(serviceName, clusters)
+	return s.SubCallback.IsSubscribed(serviceName, clusters)
 }

--- a/clients/naming_client/naming_cache/subscribe_callback_test.go
+++ b/clients/naming_client/naming_cache/subscribe_callback_test.go
@@ -55,12 +55,12 @@ func TestEventDispatcher_AddCallbackFuncs(t *testing.T) {
 		Clusters:    []string{"default"},
 		GroupName:   "public",
 		SubscribeCallback: func(services []model.Instance, err error) {
-			fmt.Println(util.ToJsonString(ed.callbackFuncMap))
+			fmt.Println(util.ToJsonString(ed.CallbackFuncMap))
 		},
 	}
 	ed.AddCallbackFunc(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","), &param.SubscribeCallback)
 	key := util.GetServiceCacheKey(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","))
-	for k, v := range ed.callbackFuncMap.Items() {
+	for k, v := range ed.CallbackFuncMap.Items() {
 		assert.Equal(t, key, k, "key should be equal!")
 		funcs := v.([]*func(services []model.Instance, err error))
 		assert.Equal(t, len(funcs), 1)
@@ -99,7 +99,7 @@ func TestEventDispatcher_RemoveCallbackFuncs(t *testing.T) {
 		},
 	}
 	ed.AddCallbackFunc(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","), &param.SubscribeCallback)
-	assert.Equal(t, len(ed.callbackFuncMap.Items()), 1, "callback funcs map length should be 1")
+	assert.Equal(t, len(ed.CallbackFuncMap.Items()), 1, "callback funcs map length should be 1")
 
 	param2 := vo.SubscribeParam{
 		ServiceName: "Test",
@@ -110,16 +110,16 @@ func TestEventDispatcher_RemoveCallbackFuncs(t *testing.T) {
 		},
 	}
 	ed.AddCallbackFunc(util.GetGroupName(param2.ServiceName, param2.GroupName), strings.Join(param2.Clusters, ","), &param2.SubscribeCallback)
-	assert.Equal(t, len(ed.callbackFuncMap.Items()), 1, "callback funcs map length should be 2")
+	assert.Equal(t, len(ed.CallbackFuncMap.Items()), 1, "callback funcs map length should be 2")
 
-	for k, v := range ed.callbackFuncMap.Items() {
+	for k, v := range ed.CallbackFuncMap.Items() {
 		log.Printf("key:%s,%d", k, len(v.([]*func(services []model.Instance, err error))))
 	}
 
 	ed.RemoveCallbackFunc(util.GetGroupName(param2.ServiceName, param2.GroupName), strings.Join(param2.Clusters, ","), &param2.SubscribeCallback)
 
 	key := util.GetServiceCacheKey(util.GetGroupName(param.ServiceName, param.GroupName), strings.Join(param.Clusters, ","))
-	for k, v := range ed.callbackFuncMap.Items() {
+	for k, v := range ed.CallbackFuncMap.Items() {
 		assert.Equal(t, key, k, "key should be equal!")
 		funcs := v.([]*func(services []model.Instance, err error))
 		assert.Equal(t, len(funcs), 1)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22524871/145040990-2bc46779-2c78-4b71-90c0-4b59b100577b.png)

如图所示，向 server 端订阅可能失败。失败后本地的 ServiceInfoMap 不会包含本次失败的服务。

![image](https://user-images.githubusercontent.com/22524871/145041412-58b787c4-2bc5-47ed-9ec7-418a397c93e2.png)

兜底逻辑也失效了，会丢失订阅。因此，增加一个定时任务，去检测是否有订阅失败的服务，进行重新订阅。