### PR TITLE
bugfix: throw NewConfigProxy error

### DIFF
--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -97,7 +97,10 @@ func NewConfigClient(nc nacos_client.INacosClient) (*ConfigClient, error) {
 	}
 	config.configCacheDir = clientConfig.CacheDir + string(os.PathSeparator) + "config"
 
-	config.configProxy, err = NewConfigProxy(serverConfig, clientConfig, httpAgent)
+	if config.configProxy, err = NewConfigProxy(serverConfig, clientConfig, httpAgent); err != nil {
+		return nil, err
+	}
+
 	if clientConfig.OpenKMS {
 		kmsClient, err := kms.NewClientWithAccessKey(clientConfig.RegionId, clientConfig.AccessKey, clientConfig.SecretKey)
 		if err != nil {


### PR DESCRIPTION
Currently when [`NewConfigProxy`](https://github.com/nacos-group/nacos-sdk-go/blob/2.0.0/clients/config_client/config_client.go#L100) returns an error , `NewConfigClient` just ignored it which may cause unexpected error. 

For example, an I/O timeout error in the login method, and the next request will fail due to the lack of accessToken.