### PR TITLE
fix race

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,8 @@ jobs:
       run: |
         diff -u <(echo -n) <(gofmt -d -s .)
         diff -u <(echo -n) <(goimports -d .)
-        go test -v ./... -coverprofile=coverage.txt -covermode=atomic
+        go test -race ./... -coverprofile=coverage.txt -covermode=atomic
+        
 
     - name: Coverage
       run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,12 +2,14 @@ name: CI
 
 on:
   push:
-    branches: "master"
+    branches:
+      - master
+      - 2.0.0
   pull_request:
-    branches: "*"
-
+    branches:
+      - master
+      - 2.0.0
 jobs:
-
   build:
     name: ubuntu-latest ${{ matrix.config.go_version }}
     runs-on: ubuntu-latest
@@ -16,6 +18,14 @@ jobs:
         config:
           - go_version: 1.13
           - go_version: 1.14
+    services:
+      nacos:
+        image: nacos/nacos-server:latest
+        env:
+          MODE: standalone
+        ports:
+          - "8848:8848"
+          - "9848:9848"
     steps:
 
     - name: Set up Go 1.x

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,13 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
-      - 2.0.0
+    branches: "master"
   pull_request:
-    branches:
-      - master
-      - 2.0.0
+    branches: "*"
 jobs:
   build:
     name: ubuntu-latest ${{ matrix.config.go_version }}

--- a/clients/client_factory_test.go
+++ b/clients/client_factory_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"net"
 	"reflect"
 	"testing"
 
@@ -9,19 +10,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetConfigClient(t *testing.T) {
+func getIntranetIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "127.0.0.1"
+	}
 
+	for _, address := range addrs {
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return "127.0.0.1"
+}
+
+func TestSetConfigClient(t *testing.T) {
+	ip := getIntranetIP()
 	sc := []constant.ServerConfig{
 		*constant.NewServerConfig(
-			"console.nacos.io",
-			80,
-			constant.WithScheme("http"),
-			constant.WithContextPath("/nacos"),
+			ip,
+			8848,
+			//constant.WithScheme("http"),
+			//constant.WithContextPath("/nacos"),
 		),
 	}
 
 	cc := *constant.NewClientConfig(
-		constant.WithNamespaceId("e525eafa-f7d7-4029-83d9-008937f9d468"),
+		constant.WithNamespaceId("public"),
 		constant.WithTimeoutMs(5000),
 		constant.WithNotLoadCacheAtStart(true),
 		constant.WithLogDir("/tmp/nacos/log"),

--- a/clients/client_factory_test.go
+++ b/clients/client_factory_test.go
@@ -16,7 +16,8 @@ func TestSetConfigClient(t *testing.T) {
 			"console.nacos.io",
 			80,
 			constant.WithScheme("http"),
-			constant.WithContextPath("/nacos")),
+			constant.WithContextPath("/nacos"),
+		),
 	}
 
 	cc := *constant.NewClientConfig(
@@ -48,6 +49,41 @@ func TestSetConfigClient(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		assert.True(t, reflect.DeepEqual(nacosClientFromMap, nacosClientFromStruct))
+	})
+
+	t.Run("registry", func(t *testing.T) {
+		client, err := NewNamingClient(
+			vo.NacosClientParam{
+				ClientConfig:  &cc,
+				ServerConfigs: sc,
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		serviceName := "golang-sms@grpc"
+		_, err = client.RegisterInstance(vo.RegisterInstanceParam{
+			Ip:          "f",
+			Port:        8840,
+			ServiceName: serviceName,
+			Weight:      10,
+			Enable:      true,
+			Healthy:     true,
+			Ephemeral:   true,
+			Metadata:    map[string]string{"idc": "shanghai-xs"},
+		})
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		is, err := client.GetService(vo.GetServiceParam{
+			ServiceName: serviceName,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("is %#v", is)
 	})
 
 }


### PR DESCRIPTION
本地使用nacos 2.0.3的server，使用grpc进行服务注册与发现，在clients执行go test -race .
会有如下DATA RACE
解决方案：在相关有race的部分加锁
---
root@DESKTOP-H4LHR8C:/mnt/d/dev/go-git/nacos-sdk-go/clients# go test -race .
2022/02/08 18:27:16 [INFO] logDir:</tmp/go-build498483215/b001/log>   cacheDir:</tmp/go-build498483215/b001/cache>
2022/02/08 18:27:16 [INFO] logDir:</tmp/nacos/log>   cacheDir:</tmp/nacos/cache>
2022/02/08 18:27:16 [INFO] logDir:</tmp/nacos/log>   cacheDir:</tmp/nacos/cache>
2022/02/08 18:27:16 [INFO] logDir:</tmp/nacos/log>   cacheDir:</tmp/nacos/cache>
2022-02-08T18:27:16.720+0800    INFO    naming_http/push_receiver.go:85 udp server start, port: 55170
2022-02-08T18:27:16.720+0800    INFO    naming_http/push_receiver.go:85 udp server start, port: 55615
2022-02-08T18:27:16.721+0800    INFO    rpc/rpc_client.go:276   f1fae170-eb65-4184-94b6-cc4f8a1858ef register server push request:ConnectResetRequest handler%!(EXTRA *rpc.ConnectResetRequestHandler=&{})
2022-02-08T18:27:16.721+0800    INFO    rpc/rpc_client.go:276   f1fae170-eb65-4184-94b6-cc4f8a1858ef register server push request:ClientDetectionRequest handler%!(EXTRA *rpc.ClientDetectionRequestHandler=&{})
2022-02-08T18:27:16.721+0800    INFO    rpc/rpc_client.go:214   [RpcClient.Start] f1fae170-eb65-4184-94b6-cc4f8a1858ef try to connect to server on start up, server: {serverIp:192.168.1.236 serverPort:8848}
2022-02-08T18:27:16.722+0800    INFO    util/common.go:95       Local IP:172.31.210.240
2022-02-08T18:27:16.829+0800    INFO    rpc/rpc_client.go:224   f1fae170-eb65-4184-94b6-cc4f8a1858ef success to connect to server {serverIp:192.168.1.236 serverPort:8848} on start up, connectionId=1644316036696_192.168.1.70_1400
2022-02-08T18:27:16.829+0800    INFO    rpc/rpc_client.go:276   f1fae170-eb65-4184-94b6-cc4f8a1858ef register server push request:NotifySubscriberRequest handler%!(EXTRA *rpc.NamingPushRequestHandler=&{0xc00011d0e0})

2022-02-08T18:27:16.830+0800    INFO    rpc/rpc_client.go:284   f1fae170-eb65-4184-94b6-cc4f8a1858ef register connection listener [*naming_grpc.ConnectionEventListener] to current client
==================

WARNING: DATA RACE
Write at 0x00c000142bf0 by goroutine 10:
  github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc.(*RpcClient).RegisterConnectionListener()
      /mnt/d/dev/go-git/nacos-sdk-go/common/remote/rpc/rpc_client.go:285 +0x284
  github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client/naming_grpc.NewNamingGrpcProxy()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/naming_client/naming_grpc/naming_grpc_proxy.go:75 +0x94e
  github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client.NewNamingProxyDelegate()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/naming_client/naming_proxy_delegate.go:51 +0x1a7
  github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client.NewNamingClient()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/naming_client/naming_client.go:72 +0x489
  github.com/nacos-group/nacos-sdk-go/v2/clients.NewNamingClient()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/client_factory.go:61 +0x69
  github.com/nacos-group/nacos-sdk-go/v2/clients.TestSetConfigClient.func3()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/client_factory_test.go:55 +0x92
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47

Previous read at 0x00c000142bf0 by goroutine 14:
  github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc.(*RpcClient).notifyConnectionEvent()
      /mnt/d/dev/go-git/nacos-sdk-go/common/remote/rpc/rpc_client.go:361 +0x4b
  github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc.(*RpcClient).Start.func1()
      /mnt/d/dev/go-git/nacos-sdk-go/common/remote/rpc/rpc_client.go:173 +0x64

Goroutine 10 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x726
  github.com/nacos-group/nacos-sdk-go/v2/clients.TestSetConfigClient()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/client_factory_test.go:54 +0x516
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47

Goroutine 14 (running) created at:
  github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc.(*RpcClient).Start()
      /mnt/d/dev/go-git/nacos-sdk-go/common/remote/rpc/rpc_client.go:170 +0xf8
  github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client/naming_grpc.NewNamingGrpcProxy()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/naming_client/naming_grpc/naming_grpc_proxy.go:68 +0x364
  github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client.NewNamingProxyDelegate()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/naming_client/naming_proxy_delegate.go:51 +0x1a7
  github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client.NewNamingClient()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/naming_client/naming_client.go:72 +0x489
  github.com/nacos-group/nacos-sdk-go/v2/clients.NewNamingClient()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/client_factory.go:61 +0x69
  github.com/nacos-group/nacos-sdk-go/v2/clients.TestSetConfigClient.func3()
      /mnt/d/dev/go-git/nacos-sdk-go/clients/client_factory_test.go:55 +0x92
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()

      /usr/local/go/src/testing/testing.go:1306 +0x47
==================

2022-02-08T18:27:16.830+0800    INFO    naming_grpc/naming_grpc_proxy.go:88     instance namespaceId:<e525eafa-f7d7-4029-83d9-008937f9d468>,serviceName:<[golang-sms@grpc](mailto:golang-sms@grpc)> with instance:<[{"instanceId":"","ip":"f","port":8840,"weight":10,"healthy":true,"enabled":true,"ephemeral":true,"clusterName":"","serviceName":"","metadata":{"idc":"shanghai-xs"},"instanceHeartBeatInterval":0,"ipDeleteTimeout":0,"instanceHeartBeatTimeOut":0}](https://github.com/nacos-group/nacos-sdk-go/compare/%7B%22instanceId%22:%22%22,%22ip%22:%22f%22,%22port%22:8840,%22weight%22:10,%22healthy%22:true,%22enabled%22:true,%22ephemeral%22:true,%22clusterName%22:%22%22,%22serviceName%22:%22%22,%22metadata%22:%7B%22idc%22:%22shanghai-xs%22%7D,%22instanceHeartBeatInterval%22:0,%22ipDeleteTimeout%22:0,%22instanceHeartBeatTimeOut%22:0%7D)>
2022-02-08T18:27:16.833+0800    WARN    naming_grpc/connection_event_listener.go:100    CacheInstanceForRedo get cache instance is null,key:DEFAULT_GROUP@@golang-sms@grpc
2022-02-08T18:27:16.836+0800    INFO    naming_cache/service_info_holder.go:92  service not found in cache DEFAULT_GROUP@@golang-sms@grpc
--- FAIL: TestSetConfigClient (0.12s)
    --- FAIL: TestSetConfigClient/registry (0.12s)
        client_factory_test.go:86: is model.Service{CacheMillis:0x2710, Hosts:[]model.Instance{}, Checksum:"", LastRefTime:0x17ed8df4db4, Clusters:"", Name:"golang-sms@grpc", GroupName:"DEFAULT_GROUP", Valid:true, AllIPs:false, ReachProtectionThreshold:false}
        testing.go:1152: race detected during execution of test
    testing.go:1152: race detected during execution of test
FAIL
FAIL    github.com/nacos-group/nacos-sdk-go/v2/clients  0.136s
FAIL
root@DESKTOP-H4LHR8C:/mnt/d/dev/go-git/nacos-sdk-go/clients#