### PR TITLE
fix nacos reboot, app cant re register

### DIFF
--- a/clients/naming_client/naming_grpc/connection_event_listener.go
+++ b/clients/naming_client/naming_grpc/connection_event_listener.go
@@ -98,9 +98,8 @@ func (c *ConnectionEventListener) CacheInstanceForRedo(serviceName, groupName st
 	getInstance, ok := c.registeredInstanceCached.Get(key)
 	if !ok {
 		logger.Warnf("CacheInstanceForRedo get cache instance is null,key:%s", key)
-		return
 	}
-	if reflect.DeepEqual(getInstance.(model.Instance), instance) {
+	if getInstance != nil && reflect.DeepEqual(getInstance.(model.Instance), instance) {
 		return
 	}
 	c.registeredInstanceCached.Set(key, instance)


### PR DESCRIPTION
when  nacos reboot， app  cant re register,   should modify  file "connection_event_listener.go" 
`
func (c *ConnectionEventListener) CacheInstanceForRedo(serviceName, groupName string, instance model.Instance) {
	key := util.GetGroupName(serviceName, groupName)
	getInstance, ok := c.registeredInstanceCached.Get(key)
	if !ok {
		logger.Warnf("CacheInstanceForRedo get cache instance is null,key:%s", key)
	}
	if getInstance != nil && reflect.DeepEqual(getInstance.(model.Instance), instance) {
		return
	}
	c.registeredInstanceCached.Set(key, instance)
}
` 