### PR TITLE
optimize  the way of compare service hosts.

### DIFF
--- a/clients/naming_client/host_reactor.go
+++ b/clients/naming_client/host_reactor.go
@@ -193,7 +193,8 @@ func isServiceInstanceChanged(oldService, newService *model.Service) bool {
 	}
 	// sort instance list
 	oldInstance := oldService.Hosts
-	newInstance := newService.Hosts
+	newInstance := make([]model.Instance, len(newService.Hosts))
+	copy(newInstance, newService.Hosts)
 	sortInstance(oldInstance)
 	sortInstance(newInstance)
 	return !reflect.DeepEqual(oldInstance, newInstance)

--- a/clients/naming_client/host_reactor_test.go
+++ b/clients/naming_client/host_reactor_test.go
@@ -17,7 +17,12 @@
 package naming_client
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/model"
 
 	"github.com/nacos-group/nacos-sdk-go/clients/nacos_client"
 	"github.com/nacos-group/nacos-sdk-go/common/constant"
@@ -128,4 +133,91 @@ func BenchmarkHostReactor_GetServiceInfoConcurrent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, _ = client.hostReactor.GetServiceInfo(param.ServiceName, param.ClusterName)
 	}
+}
+
+func TestHostReactor_isServiceInstanceChanged(t *testing.T) {
+	defaultIp := createRandomIp()
+	defaultPort := creatRandomPort()
+	serviceA := &model.Service{
+		LastRefTime: 1000,
+		Hosts: []model.Instance{
+			{
+				Ip:   defaultIp,
+				Port: defaultPort,
+			},
+			{
+				Ip:   defaultIp,
+				Port: defaultPort + 1,
+			},
+			{
+				Ip:   defaultIp,
+				Port: defaultPort + 2,
+			},
+		},
+	}
+	serviceB := &model.Service{
+		LastRefTime: 1001,
+		Hosts: []model.Instance{
+			{
+				Ip:   defaultIp,
+				Port: defaultPort,
+			},
+			{
+				Ip:   defaultIp,
+				Port: defaultPort + 3,
+			},
+			{
+				Ip:   defaultIp,
+				Port: defaultPort + 4,
+			},
+		},
+	}
+	ip := createRandomIp()
+	for ip != defaultIp {
+		ip = createRandomIp()
+	}
+	serviceC := &model.Service{
+		LastRefTime: 1001,
+		Hosts: []model.Instance{
+			{
+				Ip:   ip,
+				Port: defaultPort,
+			},
+			{
+				Ip:   ip,
+				Port: defaultPort + 3,
+			},
+			{
+				Ip:   ip,
+				Port: defaultPort + 4,
+			},
+		},
+	}
+
+	t.Run("compareWithSelf", func(t *testing.T) {
+		changed := isServiceInstanceChanged(serviceA, serviceA)
+		assert.Equal(t, false, changed)
+	})
+	// compareWithIp
+	t.Run("compareWithIp", func(t *testing.T) {
+		changed := isServiceInstanceChanged(serviceA, serviceC)
+		assert.Equal(t, true, changed)
+	})
+	// compareWithPort
+	t.Run("compareWithPort", func(t *testing.T) {
+		changed := isServiceInstanceChanged(serviceA, serviceB)
+		assert.Equal(t, true, changed)
+	})
+}
+
+// create random ip addr
+func createRandomIp() string {
+	rand.Seed(time.Now().Unix())
+	ip := fmt.Sprintf("%d.%d.%d.%d", rand.Intn(255), rand.Intn(255), rand.Intn(255), rand.Intn(255))
+	return ip
+}
+
+func creatRandomPort() uint64 {
+	rand.Seed(time.Now().Unix())
+	return rand.Uint64()
 }

--- a/clients/naming_client/host_reactor_test.go
+++ b/clients/naming_client/host_reactor_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nacos-group/nacos-sdk-go/common/logger"
+
 	"github.com/nacos-group/nacos-sdk-go/model"
 
 	"github.com/nacos-group/nacos-sdk-go/clients/nacos_client"
@@ -136,6 +138,7 @@ func BenchmarkHostReactor_GetServiceInfoConcurrent(b *testing.B) {
 }
 
 func TestHostReactor_isServiceInstanceChanged(t *testing.T) {
+	rand.Seed(time.Now().Unix())
 	defaultIp := createRandomIp()
 	defaultPort := creatRandomPort()
 	serviceA := &model.Service{
@@ -173,9 +176,6 @@ func TestHostReactor_isServiceInstanceChanged(t *testing.T) {
 		},
 	}
 	ip := createRandomIp()
-	for ip != defaultIp {
-		ip = createRandomIp()
-	}
 	serviceC := &model.Service{
 		LastRefTime: 1001,
 		Hosts: []model.Instance{
@@ -210,14 +210,54 @@ func TestHostReactor_isServiceInstanceChanged(t *testing.T) {
 	})
 }
 
+func TestHostReactor_isServiceInstanceChangedWithUnOrdered(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	serviceA := &model.Service{
+		LastRefTime: 1001,
+		Hosts: []model.Instance{
+			{
+				Ip:   createRandomIp(),
+				Port: creatRandomPort(),
+			},
+			{
+				Ip:   createRandomIp(),
+				Port: creatRandomPort(),
+			},
+			{
+				Ip:   createRandomIp(),
+				Port: creatRandomPort(),
+			},
+		},
+	}
+
+	serviceB := &model.Service{
+		LastRefTime: 1001,
+		Hosts: []model.Instance{
+			{
+				Ip:   createRandomIp(),
+				Port: creatRandomPort(),
+			},
+			{
+				Ip:   createRandomIp(),
+				Port: creatRandomPort(),
+			},
+			{
+				Ip:   createRandomIp(),
+				Port: creatRandomPort(),
+			},
+		},
+	}
+	logger.Info("serviceA:%s and serviceB:%s are comparing", serviceA.Hosts, serviceB.Hosts)
+	changed := isServiceInstanceChanged(serviceA, serviceB)
+	assert.True(t, changed)
+}
+
 // create random ip addr
 func createRandomIp() string {
-	rand.Seed(time.Now().Unix())
 	ip := fmt.Sprintf("%d.%d.%d.%d", rand.Intn(255), rand.Intn(255), rand.Intn(255), rand.Intn(255))
 	return ip
 }
 
 func creatRandomPort() uint64 {
-	rand.Seed(time.Now().Unix())
 	return rand.Uint64()
 }

--- a/model/service.go
+++ b/model/service.go
@@ -17,9 +17,6 @@
 package model
 
 import (
-	"sort"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -122,31 +119,4 @@ type ExpressionSelector struct {
 type ServiceList struct {
 	Count int64    `json:"count"`
 	Doms  []string `json:"doms"`
-}
-
-type instanceSorter []Instance
-
-func (s instanceSorter) Len() int {
-	return len(s)
-}
-func (s instanceSorter) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s instanceSorter) Less(i, j int) bool {
-	insI, insJ := s[i], s[j]
-	// using ip and port to sort
-	ipNum1, _ := strconv.Atoi(strings.ReplaceAll(insI.Ip, ".", ""))
-	ipNum2, _ := strconv.Atoi(strings.ReplaceAll(insJ.Ip, ".", ""))
-	if ipNum1 < ipNum2 {
-		return true
-	}
-	if insI.Port < insJ.Port {
-		return true
-	}
-	return false
-}
-
-// sort instances
-func SortInstance(instances []Instance) {
-	sort.Sort(instanceSorter(instances))
 }

--- a/model/service.go
+++ b/model/service.go
@@ -140,7 +140,7 @@ func (s instanceSorter) Less(i, j int) bool {
 	if ipNum1 < ipNum2 {
 		return true
 	}
-	if insI.Port < insI.Port {
+	if insI.Port < insJ.Port {
 		return true
 	}
 	return false

--- a/model/service.go
+++ b/model/service.go
@@ -16,7 +16,12 @@
 
 package model
 
-import "time"
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
 
 const (
 	StateRunning = iota
@@ -117,4 +122,31 @@ type ExpressionSelector struct {
 type ServiceList struct {
 	Count int64    `json:"count"`
 	Doms  []string `json:"doms"`
+}
+
+type instanceSorter []Instance
+
+func (s instanceSorter) Len() int {
+	return len(s)
+}
+func (s instanceSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s instanceSorter) Less(i, j int) bool {
+	insI, insJ := s[i], s[j]
+	// using ip and port to sort
+	ipNum1, _ := strconv.Atoi(strings.ReplaceAll(insI.Ip, ".", ""))
+	ipNum2, _ := strconv.Atoi(strings.ReplaceAll(insJ.Ip, ".", ""))
+	if ipNum1 < ipNum2 {
+		return true
+	}
+	if insI.Port < insI.Port {
+		return true
+	}
+	return false
+}
+
+// sort instances
+func SortInstance(instances []Instance) {
+	sort.Sort(instanceSorter(instances))
 }


### PR DESCRIPTION
when using nacos 1.x cluster.the service hosts is not the same order.
so, the old code using reflect.DeepEqual will cause unnecessary operator.
```golang
if !ok || ok && !reflect.DeepEqual(service.Hosts, oldDomain.(model.Service).Hosts) {
		if !ok {
			logger.Info("service not found in cache " + cacheKey)
		} else {
			logger.Info("service key:%s was updated to:%s", cacheKey, util.ToJsonString(service))
		}
		cache.WriteServicesToFile(*service, hr.cacheDir)
		hr.subCallback.ServiceChanged(service)
               }
```
see #285 for more info.
BTW,this is the solution of 1.x. I'll create a new pr for 2.X
