### PR TITLE
add config limiter for config client

### DIFF
--- a/clients/cache/disk_cache.go
+++ b/clients/cache/disk_cache.go
@@ -35,16 +35,18 @@ func GetFileName(cacheKey string, cacheDir string) string {
 	return cacheDir + string(os.PathSeparator) + cacheKey
 }
 
-func WriteServicesToFile(service model.Service, cacheDir string) {
-	file.MkdirIfNecessary(cacheDir)
-	sb, _ := json.Marshal(service)
-	domFileName := GetFileName(util.GetServiceCacheKey(service.Name, service.Clusters), cacheDir)
-
-	err := ioutil.WriteFile(domFileName, sb, 0666)
+func WriteServicesToFile(service *model.Service, cacheKey, cacheDir string) {
+	err := file.MkdirIfNecessary(cacheDir)
 	if err != nil {
-		logger.Errorf("failed to write name cache:%s ,value:%s ,err:%+v", domFileName, string(sb), err)
+		logger.Errorf("mkdir cacheDir failed,cacheDir:%s,err:", cacheDir, err)
+		return
 	}
-
+	bytes, _ := json.Marshal(service)
+	domFileName := GetFileName(cacheKey, cacheDir)
+	err = ioutil.WriteFile(domFileName, bytes, 0666)
+	if err != nil {
+		logger.Errorf("failed to write name cache:%s ,value:%s ,err:%v", domFileName, string(bytes), err)
+	}
 }
 
 func ReadServicesFromFile(cacheDir string) map[string]model.Service {

--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -99,7 +99,8 @@ func NewConfigClient(nc nacos_client.INacosClient) (*ConfigClient, error) {
 	if err = initLogger(clientConfig); err != nil {
 		return nil, err
 	}
-	config.configCacheDir = clientConfig.CacheDir + string(os.PathSeparator) + "config"
+	clientConfig.CacheDir = clientConfig.CacheDir + string(os.PathSeparator) + "config"
+	config.configCacheDir = clientConfig.CacheDir
 
 	if config.configProxy, err = NewConfigProxy(serverConfig, clientConfig, httpAgent); err != nil {
 		return nil, err

--- a/clients/config_client/config_client_test.go
+++ b/clients/config_client/config_client_test.go
@@ -17,7 +17,10 @@
 package config_client
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/util"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_request"
@@ -59,6 +62,10 @@ type MockConfigProxy struct {
 }
 
 func (m *MockConfigProxy) queryConfig(dataId, group, tenant string, timeout uint64, notify bool, client *ConfigClient) (*rpc_response.ConfigQueryResponse, error) {
+	cacheKey := util.GetConfigCacheKey(dataId, group, tenant)
+	if IsLimited(cacheKey) {
+		return nil, errors.New("request is limited")
+	}
 	return &rpc_response.ConfigQueryResponse{Content: "hello world"}, nil
 }
 func (m *MockConfigProxy) searchConfigProxy(param vo.SearchConfigParm, tenant, accessKey, secretKey string) (*model.ConfigPage, error) {

--- a/clients/config_client/limiter.go
+++ b/clients/config_client/limiter.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config_client
+
+import (
+	"sync"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/clients/cache"
+	"golang.org/x/time/rate"
+)
+
+type rateLimiterCheck struct {
+	rateLimiterCache cache.ConcurrentMap // cache
+	mux              sync.Mutex
+}
+
+var checker rateLimiterCheck
+
+func init() {
+	checker = rateLimiterCheck{
+		rateLimiterCache: cache.NewConcurrentMap(),
+		mux:              sync.Mutex{},
+	}
+}
+
+// IsLimited return true when request is limited
+func IsLimited(checkKey string) bool {
+	checker.mux.Lock()
+	defer checker.mux.Unlock()
+	var limiter *rate.Limiter
+	lm, exist := checker.rateLimiterCache.Get(checkKey)
+	if !exist {
+		// define a new limiter,allow 5 times per second,and reserve stock is 5.
+		limiter = rate.NewLimiter(rate.Limit(5), 5)
+		checker.rateLimiterCache.Set(checkKey, limiter)
+	} else {
+		limiter = lm.(*rate.Limiter)
+	}
+	add := time.Now().Add(time.Second)
+	return !limiter.AllowN(add, 1)
+}

--- a/clients/config_client/limiter_test.go
+++ b/clients/config_client/limiter_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config_client
+
+import (
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiter(t *testing.T) {
+	client := createConfigClientTest()
+	success, err := client.PublishConfig(vo.ConfigParam{
+		DataId:  localConfigTest.DataId,
+		Group:   "default-group",
+		Content: "hello world"})
+
+	assert.Nil(t, err)
+	assert.True(t, success)
+
+	for i := 0; i <= 10; i++ {
+		content, err := client.GetConfig(vo.ConfigParam{
+			DataId: localConfigTest.DataId,
+			Group:  "default-group"})
+		if i > 4 {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, "hello world", content)
+		}
+	}
+}

--- a/clients/naming_client/naming_cache/service_info_holder.go
+++ b/clients/naming_client/naming_cache/service_info_holder.go
@@ -94,7 +94,7 @@ func (s *ServiceInfoHolder) ProcessService(service *model.Service) {
 	s.ServiceInfoMap.Set(cacheKey, *service)
 	if !ok || checkInstanceChanged(oldDomain, service) {
 		logger.Infof("service key:%s was updated to:%s", cacheKey, util.ToJsonString(service))
-		cache.WriteServicesToFile(*service, s.cacheDir)
+		cache.WriteServicesToFile(service, cacheKey, s.cacheDir)
 		s.subCallback.ServiceChanged(cacheKey, service)
 	}
 	monitor.GetServiceInfoMapSizeMonitor().Set(float64(s.ServiceInfoMap.Count()))

--- a/clients/naming_client/naming_http/push_receiver.go
+++ b/clients/naming_client/naming_http/push_receiver.go
@@ -76,8 +76,8 @@ func (us *PushReceiver) startServer() {
 		ok   bool
 	)
 
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 3; i++ {
-		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		port := r.Intn(1000) + 54951
 		us.port = port
 		conn, ok = us.tryListen()

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	google.golang.org/grpc v1.36.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 h1:Vv0JUPWTyeqUq42B2WJ1FeIDjjvGKoA2Ss+Ts0lAVbs=
+golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=


### PR DESCRIPTION
Add limiter for config request to avoid dealing too much GetConfig request in nacos-server.
The trial limiter configuration is allow 5 request per second,and max reserver stock is 5 too.which is the same as Java nacos client.