### PR TITLE
feature.add limiter for config client.

### DIFF
--- a/clients/config_client/config_client_test.go
+++ b/clients/config_client/config_client_test.go
@@ -17,7 +17,10 @@
 package config_client
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/util"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_request"
@@ -59,6 +62,10 @@ type MockConfigProxy struct {
 }
 
 func (m *MockConfigProxy) queryConfig(dataId, group, tenant string, timeout uint64, notify bool, client *ConfigClient) (*rpc_response.ConfigQueryResponse, error) {
+	cacheKey := util.GetConfigCacheKey(dataId, group, tenant)
+	if IsLimited(cacheKey) {
+		return nil, errors.New("request is limited")
+	}
 	return &rpc_response.ConfigQueryResponse{Content: "hello world"}, nil
 }
 func (m *MockConfigProxy) searchConfigProxy(param vo.SearchConfigParm, tenant, accessKey, secretKey string) (*model.ConfigPage, error) {

--- a/clients/config_client/limiter.go
+++ b/clients/config_client/limiter.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config_client
+
+import (
+	"sync"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/clients/cache"
+	"golang.org/x/time/rate"
+)
+
+type rateLimiterCheck struct {
+	rateLimiterCache cache.ConcurrentMap // cache
+	mux              sync.Mutex
+}
+
+var checker rateLimiterCheck
+
+func init() {
+	checker = rateLimiterCheck{
+		rateLimiterCache: cache.NewConcurrentMap(),
+		mux:              sync.Mutex{},
+	}
+}
+
+// IsLimited return true when request is limited
+func IsLimited(checkKey string) bool {
+	checker.mux.Lock()
+	defer checker.mux.Unlock()
+	var limiter *rate.Limiter
+	lm, exist := checker.rateLimiterCache.Get(checkKey)
+	if !exist {
+		// define a new limiter,allow 5 times per second,and reserve stock is 5.
+		limiter = rate.NewLimiter(rate.Limit(5), 5)
+		checker.rateLimiterCache.Set(checkKey, limiter)
+	} else {
+		limiter = lm.(*rate.Limiter)
+	}
+	add := time.Now().Add(time.Second)
+	return !limiter.AllowN(add, 1)
+}

--- a/clients/config_client/limiter_test.go
+++ b/clients/config_client/limiter_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config_client
+
+import (
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiter(t *testing.T) {
+	client := createConfigClientTest()
+	success, err := client.PublishConfig(vo.ConfigParam{
+		DataId:  localConfigTest.DataId,
+		Group:   "default-group",
+		Content: "hello world"})
+
+	assert.Nil(t, err)
+	assert.True(t, success)
+
+	for i := 0; i <= 10; i++ {
+		content, err := client.GetConfig(vo.ConfigParam{
+			DataId: localConfigTest.DataId,
+			Group:  "default-group"})
+		if i > 4 {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, "hello world", content)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	google.golang.org/grpc v1.36.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 h1:Vv0JUPWTyeqUq42B2WJ1FeIDjjvGKoA2Ss+Ts0lAVbs=
+golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=


### PR DESCRIPTION
Add limiter for config request to avoid dealing too much GetConfig request in nacos-server.
The trial limiter configuration is allow 5 request per second,and max reserver stock is 5 too.which is the same as Java nacos client.