### PR TITLE
Fix leaking of goroutines of naming client.

### DIFF
--- a/clients/naming_client/naming_http/naming_http_proxy.go
+++ b/clients/naming_client/naming_http/naming_http_proxy.go
@@ -40,6 +40,7 @@ type NamingHttpProxy struct {
 	nacosServer       *nacos_server.NacosServer
 	beatReactor       BeatReactor
 	serviceInfoHolder *naming_cache.ServiceInfoHolder
+	pushReceiver      *PushReceiver
 }
 
 // NewNamingHttpProxy  create naming http proxy
@@ -52,8 +53,9 @@ func NewNamingHttpProxy(clientCfg constant.ClientConfig, nacosServer *nacos_serv
 	}
 
 	srvProxy.beatReactor = NewBeatReactor(clientCfg, nacosServer)
+	srvProxy.pushReceiver = NewPushReceiver(serviceInfoHolder)
 
-	NewPushReceiver(serviceInfoHolder).startServer()
+	srvProxy.pushReceiver.startServer()
 
 	return &srvProxy, nil
 }
@@ -210,5 +212,6 @@ func (proxy *NamingHttpProxy) Unsubscribe(serviceName, groupName, clusters strin
 }
 
 func (proxy *NamingHttpProxy) CloseClient() {
-
+	proxy.beatReactor.Close()
+	proxy.pushReceiver.Close()
 }

--- a/clients/naming_client/naming_proxy_delegate.go
+++ b/clients/naming_client/naming_proxy_delegate.go
@@ -30,6 +30,7 @@ import (
 
 // NamingProxyDelegate ...
 type NamingProxyDelegate struct {
+	nacosServer       *nacos_server.NacosServer
 	httpClientProxy   *naming_http.NamingHttpProxy
 	grpcClientProxy   *naming_grpc.NamingGrpcProxy
 	serviceInfoHolder *naming_cache.ServiceInfoHolder
@@ -54,6 +55,7 @@ func NewNamingProxyDelegate(clientCfg constant.ClientConfig, serverCfgs []consta
 	}
 
 	return &NamingProxyDelegate{
+		nacosServer:       nacosServer,
 		httpClientProxy:   httpClientProxy,
 		grpcClientProxy:   grpcClientProxy,
 		serviceInfoHolder: serviceInfoHolder,
@@ -110,5 +112,7 @@ func (proxy *NamingProxyDelegate) Unsubscribe(serviceName, groupName, clusters s
 }
 
 func (proxy *NamingProxyDelegate) CloseClient() {
+	proxy.nacosServer.Close()
+	proxy.httpClientProxy.CloseClient()
 	proxy.grpcClientProxy.CloseClient()
 }

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -54,6 +54,7 @@ func NewGrpcClient(clientName string, nacosServer *nacos_server.NacosServer) *Gr
 			nacosServer:                 nacosServer,
 			serverRequestHandlerMapping: make(map[string]ServerRequestHandlerMapping, 8),
 			mux:                         new(sync.Mutex),
+			stopChan:                    make(chan struct{}),
 		},
 	}
 	rpcClient.RpcClient.lastActiveTimestamp.Store(time.Now())


### PR DESCRIPTION
The `naming client` creates a few background goroutines to handle service info updating, service instance heart beating, gRPC connection reconnecting, etc. Most of the created goroutines are still working even if the `naming client` has been closed. This would be a big problem if the user creates many different naming clients and the lifecycle of the clients are shorter than the program.

This PR fixed the problem of `naming client`, however,  the `config client` still has the same issue. I may propose another PR to fix the same problem of `config client` later.

BTW, #517 is somehow caused by this goroutine leaking problem. And it has been fixed by this PR too.
