### PR TITLE
fix: update ConfigItem.Id type to be compatible with Nacos v1.2 server

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -16,14 +16,18 @@
 
 package model
 
+import (
+	"encoding/json"
+)
+
 type ConfigItem struct {
-	Id      string `param:"id"`
-	DataId  string `param:"dataId"`
-	Group   string `param:"group"`
-	Content string `param:"content"`
-	Md5     string `param:"md5"`
-	Tenant  string `param:"tenant"`
-	Appname string `param:"appname"`
+	Id      json.Number `param:"id"`
+	DataId  string      `param:"dataId"`
+	Group   string      `param:"group"`
+	Content string      `param:"content"`
+	Md5     string      `param:"md5"`
+	Tenant  string      `param:"tenant"`
+	Appname string      `param:"appname"`
 }
 type ConfigPage struct {
 	TotalCount     int          `param:"totalCount"`


### PR DESCRIPTION
在 1.2.1 及以下版本中，接口返回 ConfigItem.Id 是数字类型, 而 SDK 中是 string 类型。修复 SDK 与部分低版本 Nacos 服务接口不兼容的问题。

![image](https://user-images.githubusercontent.com/25881576/217169765-7c7ca478-51ab-4224-9108-9d244fbe99ba.png)
