### PR TITLE
Fix MaxInt64 overflows on ARM 32-bits

### DIFF
--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -138,9 +138,8 @@ func NewConfigClient(nc nacos_client.INacosClient) (*ConfigClient, error) {
 
 	config.cacheMap = cache.NewConcurrentMap()
 	// maximum buffered queue to prevent chan deadlocks during frequent configuration file updates
-	// fix overflows on ARM 32-bits
-	max := int64(math.MaxInt64)
-	config.listenExecute = make(chan struct{}, max)
+	// use Math.MaxInt to avoid overflows on ARM 32-bits
+	config.listenExecute = make(chan struct{}, math.MaxInt)
 
 	config.startInternal()
 

--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -138,8 +138,8 @@ func NewConfigClient(nc nacos_client.INacosClient) (*ConfigClient, error) {
 
 	config.cacheMap = cache.NewConcurrentMap()
 	// maximum buffered queue to prevent chan deadlocks during frequent configuration file updates
-	// use Math.MaxInt to avoid overflows on ARM 32-bits
-	config.listenExecute = make(chan struct{}, math.MaxInt)
+	// use Math.MaxInt32 to avoid overflows on ARM 32-bits
+	config.listenExecute = make(chan struct{}, math.MaxInt32)
 
 	config.startInternal()
 

--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -138,7 +138,9 @@ func NewConfigClient(nc nacos_client.INacosClient) (*ConfigClient, error) {
 
 	config.cacheMap = cache.NewConcurrentMap()
 	// maximum buffered queue to prevent chan deadlocks during frequent configuration file updates
-	config.listenExecute = make(chan struct{}, math.MaxInt64)
+	// fix overflows on ARM 32-bits
+	max := int64(math.MaxInt64)
+	config.listenExecute = make(chan struct{}, max)
 
 	config.startInternal()
 


### PR DESCRIPTION
`math.MaxInt64` is untyped constant. This causes overflow on a 32-bit system.

Reproduce:
```bash
$ GOARCH=arm go build example/config/main.go 
go: downloading golang.org/x/net v0.0.0-20210525063256-abc453219eb5
go: downloading golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
go: downloading golang.org/x/text v0.3.6
# github.com/nacos-group/nacos-sdk-go/v2/clients/config_client
clients\config_client\config_client.go:141:45: math.MaxInt64 (untyped int constant 9223372036854775807) overflows int
```

Edit:
`clients\config_client\config_client.go:141:45`

```go
max := int64(math.MaxInt64)
```
