### PR TITLE
调整 [INFO] logDir cacheDir 日志输出

### DIFF
--- a/clients/nacos_client/nacos_client.go
+++ b/clients/nacos_client/nacos_client.go
@@ -17,7 +17,6 @@
 package nacos_client
 
 import (
-	"log"
 	"os"
 	"strconv"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/file"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/http_agent"
+	"github.com/nacos-group/nacos-sdk-go/common/logger"
 )
 
 type NacosClient struct {
@@ -63,8 +63,7 @@ func (client *NacosClient) SetClientConfig(config constant.ClientConfig) (err er
 	}
 
 	if config.LogLevel == "info" {
-		log.SetOutput(os.Stdout)
-		log.Printf("[INFO] logDir:<%s>   cacheDir:<%s>", config.LogDir, config.CacheDir)
+		logger.Infof("logDir:<%s> cacheDir:<%s>", config.LogDir, config.CacheDir)
 	}
 
 	client.clientConfig = config

--- a/clients/nacos_client/nacos_client.go
+++ b/clients/nacos_client/nacos_client.go
@@ -62,9 +62,7 @@ func (client *NacosClient) SetClientConfig(config constant.ClientConfig) (err er
 		config.LogDir = file.GetCurrentPath() + string(os.PathSeparator) + "log"
 	}
 
-	if config.LogLevel == "info" {
-		logger.Infof("logDir:<%s> cacheDir:<%s>", config.LogDir, config.CacheDir)
-	}
+	logger.Infof("logDir:<%s> cacheDir:<%s>", config.LogDir, config.CacheDir)
 
 	client.clientConfig = config
 	client.clientConfigValid = true

--- a/clients/nacos_client/nacos_client.go
+++ b/clients/nacos_client/nacos_client.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/file"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/http_agent"
-	"github.com/nacos-group/nacos-sdk-go/common/logger"
+	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
 )
 
 type NacosClient struct {

--- a/clients/nacos_client/nacos_client.go
+++ b/clients/nacos_client/nacos_client.go
@@ -61,7 +61,12 @@ func (client *NacosClient) SetClientConfig(config constant.ClientConfig) (err er
 	if config.LogDir == "" {
 		config.LogDir = file.GetCurrentPath() + string(os.PathSeparator) + "log"
 	}
-	log.Printf("[INFO] logDir:<%s>   cacheDir:<%s>", config.LogDir, config.CacheDir)
+
+	if config.LogLevel == "info" {
+		log.SetOutput(os.Stdout)
+		log.Printf("[INFO] logDir:<%s>   cacheDir:<%s>", config.LogDir, config.CacheDir)
+	}
+
 	client.clientConfig = config
 	client.clientConfigValid = true
 


### PR DESCRIPTION
https://github.com/nacos-group/nacos-sdk-go/issues/260

这个问题曾经被提到过，但是在一次次更变中又被改了回去。

go 的默认 log 是 StdErr 通道的，这条日志打印对日志收集器存在影响。

现在改为 日志等级为 info 时才打印，并且打印到 StdOut标准输出。