### PR TITLE
解决rpc client重新连接时currentConnection变量产生竞态问题

### DIFF
--- a/common/remote/rpc/rpc_client.go
+++ b/common/remote/rpc/rpc_client.go
@@ -343,7 +343,9 @@ func (r *RpcClient) reconnect(serverInfo ServerInfo, onRequestFail bool) {
 				r.currentConnection.setAbandon(true)
 				r.closeConnection()
 			}
+			r.mux.Lock()
 			r.currentConnection = connectionNew
+			r.mux.Unlock()
 			atomic.StoreInt32((*int32)(&r.rpcClientStatus), (int32)(RUNNING))
 			r.asyncNotifyConnectionChange(CONNECTED)
 			return


### PR DESCRIPTION
解决rpc client重新连接时currentConnection变量产生竞态问题