### PR TITLE
fix #655 Repeated subscriptions result in multiple callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,17 +267,18 @@ services, err := namingClient.GetService(vo.GetServiceParam{
 * Listen service change event：Subscribe
 
 ```go
-
 // Subscribe key = serviceName+groupName+cluster
-	// Note: We call add multiple SubscribeCallback with the same key.
-	err := namingClient.Subscribe(vo.SubscribeParam{
-		ServiceName: "demo.go",
-		GroupName:   "group-a", // default value is DEFAULT_GROUP
-		Clusters:    []string{"cluster-a"}, // default value is DEFAULT
-		SubscribeCallback: func (services []model.Instance, err error) {
-			log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
-		},
-	})
+// Note: We call add multiple SubscribeCallback with the same key.
+callback := func(services []model.Instance, err error) {
+    log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
+}
+
+err := namingClient.Subscribe(vo.SubscribeParam{
+    ServiceName: "demo.go",
+    GroupName:   "group-a", // default value is DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // default value is DEFAULT
+    SubscribeCallback: callback,
+})
 
 ```
 
@@ -285,14 +286,16 @@ services, err := namingClient.GetService(vo.GetServiceParam{
 
 ```go
 
+callback := func(services []model.Instance, err error) {
+    log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
+}
+
 err := namingClient.Unsubscribe(vo.SubscribeParam{
-		ServiceName: "demo.go",
-		GroupName:   "group-a", // default value is DEFAULT_GROUP
-		Clusters:    []string{"cluster-a"}, // default value is DEFAULT
-		SubscribeCallback: func (services []model.Instance, err error) {
-			log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
-		},
-	})
+    ServiceName: "demo.go",
+    GroupName:   "group-a", // default value is DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // default value is DEFAULT
+    SubscribeCallback: callback,
+})
 
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -258,13 +258,16 @@ instance, err := namingClient.SelectOneHealthyInstance(vo.SelectOneHealthInstanc
 
 // Subscribe key=serviceName+groupName+cluster
 // 注意:我们可以在相同的key添加多个SubscribeCallback.
+
+callback := func(services []model.Instance, err error) {
+    log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
+}
+
 err := namingClient.Subscribe(vo.SubscribeParam{
     ServiceName: "demo.go",
     GroupName:   "group-a",             // 默认值DEFAULT_GROUP
     Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
-    SubscribeCallback: func(services []model.Instance, err error) {
-        log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
-    },
+    SubscribeCallback: callback,
 })
 
 ```
@@ -273,13 +276,15 @@ err := namingClient.Subscribe(vo.SubscribeParam{
 
 ```go
 
+callback := func(services []model.Instance, err error) {
+    log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
+}
+
 err := namingClient.Unsubscribe(vo.SubscribeParam{
     ServiceName: "demo.go",
     GroupName:   "group-a",             // 默认值DEFAULT_GROUP
     Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
-    SubscribeCallback: func(services []model.Instance, err error) {
-        log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
-    },
+    SubscribeCallback: callback,
 })
 
 ```

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -325,7 +325,7 @@ func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
 	clusters := strings.Join(param.Clusters, ",")
-	sc.serviceInfoHolder.RegisterCallback(util.GetGroupName(param.ServiceName, param.GroupName), clusters, &param.SubscribeCallback)
+	sc.serviceInfoHolder.RegisterCallback(util.GetGroupName(param.ServiceName, param.GroupName), clusters, param.SubscribeCallback)
 	_, err := sc.serviceProxy.Subscribe(param.ServiceName, param.GroupName, clusters)
 	return err
 }
@@ -334,7 +334,7 @@ func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
 func (sc *NamingClient) Unsubscribe(param *vo.SubscribeParam) (err error) {
 	clusters := strings.Join(param.Clusters, ",")
 	serviceFullName := util.GetGroupName(param.ServiceName, param.GroupName)
-	sc.serviceInfoHolder.DeregisterCallback(serviceFullName, clusters, &param.SubscribeCallback)
+	sc.serviceInfoHolder.DeregisterCallback(serviceFullName, clusters, param.SubscribeCallback)
 	if sc.serviceInfoHolder.IsSubscribed(serviceFullName, clusters) {
 		err = sc.serviceProxy.Unsubscribe(param.ServiceName, param.GroupName, clusters)
 	}

--- a/vo/service_param.go
+++ b/vo/service_param.go
@@ -73,10 +73,10 @@ type GetAllServiceInfoParam struct {
 }
 
 type SubscribeParam struct {
-	ServiceName       string                                     `param:"serviceName"` //required
-	Clusters          []string                                   `param:"clusters"`    //optional
-	GroupName         string                                     `param:"groupName"`   //optional,default:DEFAULT_GROUP
-	SubscribeCallback func(services []model.Instance, err error) //required
+	ServiceName       string                                      `param:"serviceName"` //required
+	Clusters          []string                                    `param:"clusters"`    //optional
+	GroupName         string                                      `param:"groupName"`   //optional,default:DEFAULT_GROUP
+	SubscribeCallback *func(services []model.Instance, err error) //required
 }
 
 type SelectAllInstancesParam struct {


### PR DESCRIPTION
### bug
初始化vo.SubscribeParam的SubscribeCallback属性时是值传递，导致"订阅”和"取消订阅"两次请求传入的回调函数不同，取消订阅逻辑总无法清除对应的callback从而产生这个bug #655。

### fix
将SubscribeCallback定义为指针类型的函数，保证"取消订阅"请求时两次回调函数符合相等性的判断。

### result
![Snipaste_2023-10-30_17-14-34](https://github.com/nacos-group/nacos-sdk-go/assets/18044355/485500e5-b769-4bf4-a4d9-9e2ae38a8c56)
