### PR TITLE
feat: export ServerHealthy in INamingClient

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -342,6 +342,11 @@ func (sc *NamingClient) Unsubscribe(param *vo.SubscribeParam) (err error) {
 	return err
 }
 
+// ServerHealthy ...
+func (sc *NamingClient) ServerHealthy() bool {
+	return sc.serviceProxy.ServerHealthy()
+}
+
 // CloseClient ...
 func (sc *NamingClient) CloseClient() {
 	sc.serviceProxy.CloseClient()

--- a/clients/naming_client/naming_client_interface.go
+++ b/clients/naming_client/naming_client_interface.go
@@ -112,6 +112,9 @@ type INamingClient interface {
 	// GetAllServicesInfo use to get all service info by page
 	GetAllServicesInfo(param vo.GetAllServiceInfoParam) (model.ServiceList, error)
 
+	// ServerHealthy use to check the connectivity to server
+	ServerHealthy() bool
+
 	//CloseClient close the GRPC client
 	CloseClient()
 }


### PR DESCRIPTION
为 `INamingClient` 接口提供 `ServerHealthy() bool` 方法，便于无副作用的进行nacos服务可用性检查 fix:https://github.com/nacos-group/nacos-sdk-go/issues/676