### PR TITLE
fix:path separator conversion for different platforms

### DIFF
--- a/common/file/file.go
+++ b/common/file/file.go
@@ -39,7 +39,14 @@ func init() {
 }
 
 func MkdirIfNecessary(createDir string) (err error) {
-	s := strings.Split(createDir, path)
+	var dirPath string
+	// replace path separator
+	if osType == WINDOWS {
+		dirPath = strings.ReplaceAll(createDir, "/", "\\")
+	} else {
+		dirPath = strings.ReplaceAll(createDir, "\\", "/")
+	}
+	s := strings.Split(dirPath, path)
 	startIndex := 0
 	dir := ""
 	if s[0] == "" {


### PR DESCRIPTION
when I input a dir as "./nacos/cache" on windows,I encountered an error:"mkdir d:\goProject\api_gw\test\./nacos/cache: The system cannot find the path specified."