### PR TITLE
[reconstruction] change configFilterChain from public sigleton to private owned by ConfigClient

### DIFF
--- a/clients/cache/const.go
+++ b/clients/cache/const.go
@@ -1,0 +1,11 @@
+package cache
+
+type ConfigCachedFileType string
+
+const (
+	ConfigContent          ConfigCachedFileType = "Config Content"
+	ConfigEncryptedDataKey ConfigCachedFileType = "Config Encrypted Data Key"
+
+	ENCRYPTED_DATA_KEY_FILE_NAME = "encrypted-data-key"
+	FAILOVER_FILE_SUFFIX         = "_failover"
+)

--- a/clients/cache/disk_cache.go
+++ b/clients/cache/disk_cache.go
@@ -160,7 +160,7 @@ func ReadEncryptedDataKeyFromFile(cacheKey string, cacheDir string) (string, err
 }
 
 func ReadConfigFromFile(cacheKey string, cacheDir string) (string, error) {
-	return readConfigFromFile(GetConfigEncryptedDataKeyFileName(cacheKey, cacheDir), ConfigEncryptedDataKey)
+	return readConfigFromFile(GetFileName(cacheKey, cacheDir), ConfigEncryptedDataKey)
 }
 
 func readConfigFromFile(fileName string, fileType ConfigCachedFileType) (string, error) {

--- a/clients/cache/disk_cache_test.go
+++ b/clients/cache/disk_cache_test.go
@@ -30,7 +30,7 @@ func TestWriteAndGetConfigToFile(t *testing.T) {
 		assert.Nil(t, err)
 
 		configFromFile, err := ReadConfigFromFile(cacheKey, dir)
-		assert.Nil(t, err)
+		assert.NotNil(t, err)
 		assert.Equal(t, configFromFile, "")
 
 		err = WriteConfigToFile(cacheKey, dir, configContent)
@@ -90,7 +90,7 @@ func TestWriteAndGetConfigToFile(t *testing.T) {
 		assert.Equal(t, fromFile, configContent)
 	})
 	t.Run("read doesn't existed config file", func(t *testing.T) {
-		dataId := "config_encryptedDataKey" + dataIdSuffix
+		dataId := "config_encryptedDataKey" + dataIdSuffix + strconv.Itoa(rand.Intn(1000))
 		cacheKey := util.GetConfigCacheKey(dataId, group, ns)
 
 		_, err := ReadConfigFromFile(cacheKey, dir)

--- a/clients/cache/disk_cache_test.go
+++ b/clients/cache/disk_cache_test.go
@@ -2,7 +2,10 @@ package cache
 
 import (
 	"fmt"
+	"github.com/nacos-group/nacos-sdk-go/v2/util"
+	"math/rand"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,9 +13,96 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v2/common/file"
 )
 
+var (
+	dir   = file.GetCurrentPath()
+	group = "FILE_GROUP"
+	ns    = "chasu"
+)
+
+func TestWriteAndGetConfigToFile(t *testing.T) {
+	dataIdSuffix := strconv.Itoa(rand.Intn(1000))
+	t.Run("write and get config content", func(t *testing.T) {
+		dataId := "config_content" + dataIdSuffix
+		cacheKey := util.GetConfigCacheKey(dataId, group, ns)
+		configContent := "config content"
+
+		err := WriteConfigToFile(cacheKey, dir, "")
+		assert.Nil(t, err)
+
+		configFromFile, err := ReadConfigFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, configFromFile, "")
+
+		err = WriteConfigToFile(cacheKey, dir, configContent)
+		assert.Nil(t, err)
+
+		fromFile, err := ReadConfigFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, fromFile, configContent)
+
+		err = WriteConfigToFile(cacheKey, dir, "")
+		assert.Nil(t, err)
+
+		configFromFile, err = ReadConfigFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, configFromFile, "")
+	})
+
+	t.Run("write and get config encryptedDataKey", func(t *testing.T) {
+		dataId := "config_encryptedDataKey" + dataIdSuffix
+		cacheKey := util.GetConfigCacheKey(dataId, group, ns)
+		configContent := "config encrypted data key"
+
+		err := WriteEncryptedDataKeyToFile(cacheKey, dir, "")
+		assert.Nil(t, err)
+
+		configFromFile, err := ReadEncryptedDataKeyFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, configFromFile, "")
+
+		err = WriteEncryptedDataKeyToFile(cacheKey, dir, configContent)
+		assert.Nil(t, err)
+
+		fromFile, err := ReadEncryptedDataKeyFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, fromFile, configContent)
+
+		err = WriteEncryptedDataKeyToFile(cacheKey, dir, "")
+		assert.Nil(t, err)
+
+		configFromFile, err = ReadEncryptedDataKeyFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, configFromFile, "")
+	})
+	t.Run("double write config file", func(t *testing.T) {
+		dataId := "config_encryptedDataKey" + dataIdSuffix
+		cacheKey := util.GetConfigCacheKey(dataId, group, ns)
+		configContent := "config encrypted data key"
+
+		err := WriteConfigToFile(cacheKey, dir, configContent)
+		assert.Nil(t, err)
+
+		err = WriteConfigToFile(cacheKey, dir, configContent)
+		assert.Nil(t, err)
+
+		fromFile, err := ReadConfigFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+		assert.Equal(t, fromFile, configContent)
+	})
+	t.Run("read doesn't existed config file", func(t *testing.T) {
+		dataId := "config_encryptedDataKey" + dataIdSuffix
+		cacheKey := util.GetConfigCacheKey(dataId, group, ns)
+
+		_, err := ReadConfigFromFile(cacheKey, dir)
+		assert.NotNil(t, err)
+
+		_, err = ReadEncryptedDataKeyFromFile(cacheKey, dir)
+		assert.Nil(t, err)
+	})
+}
+
 func TestGetFailover(t *testing.T) {
 	cacheKey := "test_failOver"
-	dir := file.GetCurrentPath()
 	fileContent := "test_failover"
 	t.Run("writeContent", func(t *testing.T) {
 		filepath := dir + string(os.PathSeparator) + cacheKey + "_failover"

--- a/clients/config_client/config_client_test.go
+++ b/clients/config_client/config_client_test.go
@@ -64,7 +64,7 @@ func createConfigClientTest() *ConfigClient {
 	return client
 }
 
-func createConfigClient() *ConfigClient {
+func createConfigClientForKmsTest() *ConfigClient {
 	nc := nacos_client.NacosClient{}
 	_ = nc.SetServerConfig([]constant.ServerConfig{*serverConfigWithOptions})
 	_ = nc.SetClientConfig(*clientConfigWithOptions)
@@ -143,28 +143,29 @@ func Test_SearchConfig(t *testing.T) {
 	assert.NotEmpty(t, configPage)
 }
 
-func TestPublishAndGetConfigByUsingLocalCache(t *testing.T) {
-	param := vo.ConfigParam{
-		DataId:  "cipher-kms-aes-256-usingCache",
-		Group:   "DEFAULT",
-		Content: "content加密&&",
-	}
-	t.Run("PublishAndGetConfigByUsingLocalCache", func(t *testing.T) {
-		client := createConfigClient()
-		_, err := client.PublishConfig(param)
-		assert.Nil(t, err)
-
-		configQueryContent, err := client.GetConfig(param)
-		assert.Nil(t, err)
-		assert.Equal(t, param.Content, configQueryContent)
-
-		resetConfigClientProxy(client, &MockConfigProxyForUsingLocalDiskCache{})
-		configQueryContentByUsingCache, err := client.GetConfig(param)
-		assert.Nil(t, err)
-		assert.Equal(t, param.Content, configQueryContentByUsingCache)
-
-	})
-}
+// only using by ak sk
+//func TestPublishAndGetConfigByUsingLocalCache(t *testing.T) {
+//	param := vo.ConfigParam{
+//		DataId:  "cipher-kms-aes-256-usingCache",
+//		Group:   "DEFAULT",
+//		Content: "content加密&&",
+//	}
+//	t.Run("PublishAndGetConfigByUsingLocalCache", func(t *testing.T) {
+//		client := createConfigClientForKmsTest()
+//		_, err := client.PublishConfig(param)
+//		assert.Nil(t, err)
+//
+//		configQueryContent, err := client.GetConfig(param)
+//		assert.Nil(t, err)
+//		assert.Equal(t, param.Content, configQueryContent)
+//
+//		resetConfigClientProxy(client, &MockConfigProxyForUsingLocalDiskCache{})
+//		configQueryContentByUsingCache, err := client.GetConfig(param)
+//		assert.Nil(t, err)
+//		assert.Equal(t, param.Content, configQueryContentByUsingCache)
+//
+//	})
+//}
 
 // PublishConfig
 func Test_PublishConfigWithoutDataId(t *testing.T) {

--- a/clients/config_client/config_proxy.go
+++ b/clients/config_client/config_proxy.go
@@ -123,7 +123,7 @@ func (cp *ConfigProxy) queryConfig(dataId, group, tenant string, timeout uint64,
 	}
 	if response.IsSuccess() {
 		cache.WriteConfigToFile(cacheKey, cp.clientConfig.CacheDir, response.Content)
-		//todo LocalConfigInfoProcessor.saveEncryptDataKeySnapshot
+		cache.WriteEncryptedDataKeyToFile(cacheKey, cp.clientConfig.CacheDir, response.EncryptedDataKey)
 		if response.ContentType == "" {
 			response.ContentType = "text"
 		}
@@ -132,7 +132,7 @@ func (cp *ConfigProxy) queryConfig(dataId, group, tenant string, timeout uint64,
 
 	if response.GetErrorCode() == 300 {
 		cache.WriteConfigToFile(cacheKey, cp.clientConfig.CacheDir, "")
-		//todo LocalConfigInfoProcessor.saveEncryptDataKeySnapshot
+		cache.WriteEncryptedDataKeyToFile(cacheKey, cp.clientConfig.CacheDir, "")
 		return response, nil
 	}
 

--- a/common/constant/const.go
+++ b/common/constant/const.go
@@ -105,7 +105,6 @@ const (
 	LOG_FILE_NAME               = "nacos-sdk.log"
 	HTTPS_SERVER_PORT           = 443
 	GRPC                        = "grpc"
-	FAILOVER_FILE_SUFFIX        = "_failover"
 	RpcPortOffset               = 1000
 	MSE_KMSv1_DEFAULT_KEY_ID    = "alias/acs/mse"
 )

--- a/common/encryption/const.go
+++ b/common/encryption/const.go
@@ -29,12 +29,14 @@ const (
 	kmsAes256KeySpec = "AES_256"
 
 	kmsScheme       = "https"
-	kmsAcceptFormat = "JSON"
+	kmsAcceptFormat = "XML"
 
 	kmsCipherAlgorithm = "AES/ECB/PKCS5Padding"
 
 	maskUnit8Width  = 8
 	maskUnit32Width = 32
+
+	KmsHandlerName = "KmsHandler"
 )
 
 var (

--- a/example/config-acm/main.go
+++ b/example/config-acm/main.go
@@ -39,7 +39,6 @@ var localClientConfigWithOptions = constant.NewClientConfig(
 	//constant.WithSecretKey(getFileContent(path.Join(getWDR(), "sk"))),
 	constant.WithAccessKey("LTAxxxgQL"),
 	constant.WithSecretKey("iG4xxxV6C"),
-	constant.WithNamespaceId("791fd262-3735-40df-a605-e3236f8ff495"),
 	constant.WithOpenKMS(true),
 	constant.WithKMSVersion(constant.KMSv1),
 	constant.WithRegionId("cn-beijing"),

--- a/example/config-mse-kmsv3/main.go
+++ b/example/config-mse-kmsv3/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 var localServerConfigWithOptions = constant.NewServerConfig(
-	"mse-1a3d3840-p.nacos-ans.mse.aliyuncs.com",
+	"mse-a8c6bf80-p.nacos-ans.mse.aliyuncs.com",
 	8848,
 )
 

--- a/example/config-mse-kmsv3/main.go
+++ b/example/config-mse-kmsv3/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 var localServerConfigWithOptions = constant.NewServerConfig(
-	"mse-a8c6bf80-p.nacos-ans.mse.aliyuncs.com",
+	"mse-cdf17f60-p.nacos-ans.mse.aliyuncs.com",
 	8848,
 )
 

--- a/example/config-mse-kmsv3/main.go
+++ b/example/config-mse-kmsv3/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/config_client"
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/nacos_client"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
-	"github.com/nacos-group/nacos-sdk-go/v2/common/filter"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/http_agent"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
 	"github.com/nacos-group/nacos-sdk-go/v2/vo"
@@ -32,7 +31,7 @@ import (
 )
 
 var localServerConfigWithOptions = constant.NewServerConfig(
-	"mse-d12e6112-p.nacos-ans.mse.aliyuncs.com",
+	"mse-1a3d3840-p.nacos-ans.mse.aliyuncs.com",
 	8848,
 )
 
@@ -42,7 +41,7 @@ var localClientConfigWithOptions = constant.NewClientConfig(
 	constant.WithNotLoadCacheAtStart(true),
 	constant.WithAccessKey(getFileContent(path.Join(getWDR(), "ak"))),
 	constant.WithSecretKey(getFileContent(path.Join(getWDR(), "sk"))),
-	constant.WithNamespaceId("791fd262-3735-40df-a605-e3236f8ff495"),
+	//constant.WithNamespaceId("791fd262-3735-40df-a605-e3236f8ff495"),
 	constant.WithOpenKMS(true),
 	constant.WithKMSVersion(constant.KMSv3),
 	constant.WithKMSv3Config(&constant.KMSv3Config{
@@ -56,27 +55,26 @@ var localClientConfigWithOptions = constant.NewClientConfig(
 
 var localConfigList = []vo.ConfigParam{
 	{
-		DataId:   "common-config",
-		Group:    "default",
-		Content:  "common",
-		KmsKeyId: "key-xxx", //可以识别
+		DataId:  "common-config",
+		Group:   "default",
+		Content: "common普通&&",
 	},
 	{
 		DataId:   "cipher-crypt",
 		Group:    "default",
-		Content:  "cipher",
+		Content:  "cipher加密&&",
 		KmsKeyId: "key-xxx", //可以识别
 	},
 	{
 		DataId:   "cipher-kms-aes-128-crypt",
 		Group:    "default",
-		Content:  "cipher-aes-128",
+		Content:  "cipher-aes-128加密&&",
 		KmsKeyId: "key-xxx", //可以识别
 	},
 	{
 		DataId:   "cipher-kms-aes-256-crypt",
 		Group:    "default",
-		Content:  "cipher-aes-256",
+		Content:  "cipher-aes-256加密&&",
 		KmsKeyId: "key-xxx", //可以识别
 	},
 }
@@ -141,24 +139,6 @@ func usingKMSv3ClientAndStoredByNacos() {
 		//wait for config change callback to execute
 		//time.Sleep(2 * time.Second)
 	}
-}
-
-func onlyUsingFilters() error {
-	createConfigClient()
-	for _, param := range localConfigList {
-		param.UsageType = vo.RequestType
-		fmt.Println("param = ", param)
-		if err := filter.GetDefaultConfigFilterChainManager().DoFilters(&param); err != nil {
-			return err
-		}
-		fmt.Println("after encrypt param = ", param)
-		param.UsageType = vo.ResponseType
-		if err := filter.GetDefaultConfigFilterChainManager().DoFilters(&param); err != nil {
-			return err
-		}
-		fmt.Println("after decrypt param = ", param)
-	}
-	return nil
 }
 
 func createConfigClient() *config_client.ConfigClient {

--- a/vo/config_param_test.go
+++ b/vo/config_param_test.go
@@ -22,19 +22,21 @@ import (
 )
 
 func TestConfigParamDeepCopy(t *testing.T) {
-	param := &ConfigParam{
-		DataId:    "dataId",
-		Group:     "",
-		Content:   "common content",
-		UsageType: RequestType,
-		OnChange: func(namespace, group, dataId, data string) {
-			//do nothing
-		},
-	}
-	paramDeepCopied := param.DeepCopy()
+	t.Run("test configParam deep copy", func(t *testing.T) {
+		param := &ConfigParam{
+			DataId:    "dataId",
+			Group:     "",
+			Content:   "common content",
+			UsageType: RequestType,
+			OnChange: func(namespace, group, dataId, data string) {
+				//do nothing
+			},
+		}
+		paramDeepCopied := param.DeepCopy()
 
-	assert.Equal(t, param.DataId, paramDeepCopied.DataId)
-	assert.Equal(t, param.Content, paramDeepCopied.Content)
-	assert.NotEqual(t, &param.OnChange, &paramDeepCopied.OnChange)
-	assert.NotEqual(t, &param, &paramDeepCopied)
+		assert.Equal(t, param.DataId, paramDeepCopied.DataId)
+		assert.Equal(t, param.Content, paramDeepCopied.Content)
+		assert.NotEqual(t, &param.OnChange, &paramDeepCopied.OnChange)
+		assert.NotEqual(t, &param, &paramDeepCopied)
+	})
 }


### PR DESCRIPTION
the `IConfigFilterChain` interface has only one default implementation global, and all `NacosConfigClient` instance objects depend on this global variable. That means the different `NacosConfigClient` will share the only one global variable, which will cause coupling effect to another `NacosConfigClient` when there are more than one `NacosConfigClient`.

-----

`IConfigFilterChain`接口只有一个默认的全局变量，而且不同的`NacosConfigClient`实例对象都依赖这个全局变量。这意味着不同的`NacosConfigClient`将共享唯一的一个全局变量，当有多个`NacosConfigClient`时，这将导致与另一个`NacosConfigClient`的耦合效应。