### PR TITLE
fix too many logger fault 

### DIFF
--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -118,6 +118,9 @@ func BuildLoggerConfig(clientConfig constant.ClientConfig) Config {
 func InitLogger(config Config) (err error) {
 	logLock.Lock()
 	defer logLock.Unlock()
+	if logger != nil {
+		return
+	}
 	logger, err = InitNacosLogger(config)
 	return
 }
@@ -157,7 +160,7 @@ func getEncoder() zapcore.EncoderConfig {
 	}
 }
 
-//SetLogger sets logger for sdk
+// SetLogger sets logger for sdk
 func SetLogger(log Logger) {
 	logLock.Lock()
 	defer logLock.Unlock()


### PR DESCRIPTION
在创建大量 Nacos Logger 的场景下面, 会造成 Logger 的 lumberjack.Logger 出现 goroutine 大量没释放

这个 PR 是为了把Logger 做成单例