### PR TITLE
🐞 fix:Adjust lock order to address concurrency issue

### DIFF
--- a/clients/naming_client/naming_cache/subscribe_callback.go
+++ b/clients/naming_client/naming_cache/subscribe_callback.go
@@ -42,8 +42,8 @@ func (ed *SubscribeCallback) IsSubscribed(serviceName, clusters string) bool {
 
 func (ed *SubscribeCallback) AddCallbackFunc(serviceName string, clusters string, callbackFunc *func(services []model.Instance, err error)) {
 	key := util.GetServiceCacheKey(serviceName, clusters)
-	defer ed.mux.Unlock()
 	ed.mux.Lock()
+	defer ed.mux.Unlock()
 	var funcSlice []*func(services []model.Instance, err error)
 	old, ok := ed.callbackFuncMap.Get(key)
 	if ok {


### PR DESCRIPTION
Adjust lock order to address concurrency issue  Moved defer ed.mux.Unlock() after ed.mux.Lock() to ensure immediate unlocking after acquiring the lock, resolving potential concurrency issues.