### PR TITLE
fix: md5 not empty when content is empty

### DIFF
--- a/util/md5.go
+++ b/util/md5.go
@@ -23,6 +23,10 @@ import (
 )
 
 func Md5(content string) (md string) {
+	if content == "" {
+		return
+	}
+
 	h := md5.New()
 	_, _ = io.WriteString(h, content)
 	md = fmt.Sprintf("%x", h.Sum(nil))

--- a/util/md5_test.go
+++ b/util/md5_test.go
@@ -25,4 +25,7 @@ import (
 func TestMd5(t *testing.T) {
 	md5 := Md5("demo")
 	assert.Equal(t, "fe01ce2a7fbac8fafaed7c982a04e229", md5)
+
+	md5 = Md5("")
+	assert.Equal(t, "", md5)
 }


### PR DESCRIPTION

- Md5 is not empty when the content of dataId is empty, which causes high frequency calls for nacos server after dataId is deleted.