### PR TITLE
fix(#811): Remove error log when matched ramCredentialProvider not found

### DIFF
--- a/common/security/ram_auth_client.go
+++ b/common/security/ram_auth_client.go
@@ -2,7 +2,6 @@ package security
 
 import (
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
-	"github.com/pkg/errors"
 )
 
 type RamContext struct {
@@ -71,9 +70,8 @@ func (rac *RamAuthClient) Login() (bool, error) {
 			break
 		}
 	}
-
 	if rac.matchedProvider == nil {
-		return false, errors.Errorf("no matched provider")
+		return false, nil
 	}
 	err := rac.matchedProvider.Init()
 	if err != nil {


### PR DESCRIPTION
Fix #811 