### PR TITLE
配置订阅支持自定义LocalIP(#872)

### DIFF
--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -111,6 +111,10 @@ func NewConfigClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 	if err != nil {
 		return nil, err
 	}
+	// Set custom client IP if configured
+	if clientConfig.ClientIP != "" {
+		util.SetCustomClientIP(clientConfig.ClientIP)
+	}
 	serverConfig, err := nc.GetServerConfig()
 	if err != nil {
 		return nil, err

--- a/common/constant/client_config_options.go
+++ b/common/constant/client_config_options.go
@@ -244,3 +244,11 @@ func WithAppConnLabels(appConnLabels map[string]string) ClientOption {
 		config.AppConnLabels = appConnLabels
 	}
 }
+
+// WithClientIP sets custom client IP for gRPC communication.
+// This is useful in containerized environments where the auto-detected IP might be incorrect.
+func WithClientIP(clientIP string) ClientOption {
+	return func(config *ClientConfig) {
+		config.ClientIP = clientIP
+	}
+}

--- a/common/constant/config.go
+++ b/common/constant/config.go
@@ -61,6 +61,7 @@ type ClientConfig struct {
 	EndpointQueryParams  string                   // the address server  endpoint query params
 	ClusterName          string                   // the address server  clusterName
 	AppConnLabels        map[string]string        // app conn labels
+	ClientIP             string                   // the custom client ip, if not set, will use local ip auto detected
 }
 
 type ClientLogSamplingConfig struct {

--- a/util/common.go
+++ b/util/common.go
@@ -67,8 +67,22 @@ func GetConfigCacheKey(dataId string, group string, tenant string) string {
 }
 
 var localIP = ""
+var customClientIP = ""
+
+// SetCustomClientIP sets a custom client IP to be used in gRPC communication.
+// This will override the auto-detected local IP.
+// Useful for containerized environments where the auto-detected IP might be incorrect.
+func SetCustomClientIP(ip string) {
+	customClientIP = ip
+	if len(customClientIP) > 0 {
+		logger.Infof("Custom Client IP set to: %s", customClientIP)
+	}
+}
 
 func LocalIP() string {
+	if customClientIP != "" {
+		return customClientIP
+	}
 	if localIP == "" {
 		netInterfaces, err := net.Interfaces()
 		if err != nil {


### PR DESCRIPTION
fix [#872](https://github.com/nacos-group/nacos-sdk-go/issues/872), provide `WithClientIP` function, use container IP instead of cilium_host IP when client sets it.