### PR TITLE
fix: handle clients/config_client errors

### DIFF
--- a/clients/config_client/config_proxy.go
+++ b/clients/config_client/config_proxy.go
@@ -134,8 +134,14 @@ func (cp *ConfigProxy) queryConfig(dataId, group, tenant string, timeout uint64,
 		return nil, errors.New("ConfigQueryRequest returns type error")
 	}
 	if response.IsSuccess() {
-		cache.WriteConfigToFile(cacheKey, cp.clientConfig.CacheDir, response.Content)
-		cache.WriteEncryptedDataKeyToFile(cacheKey, cp.clientConfig.CacheDir, response.EncryptedDataKey)
+		err = cache.WriteConfigToFile(cacheKey, cp.clientConfig.CacheDir, response.Content)
+		if err != nil {
+			return nil, err
+		}
+		err = cache.WriteEncryptedDataKeyToFile(cacheKey, cp.clientConfig.CacheDir, response.EncryptedDataKey)
+		if err != nil {
+			return nil, err
+		}
 		if response.ContentType == "" {
 			response.ContentType = "text"
 		}
@@ -143,8 +149,14 @@ func (cp *ConfigProxy) queryConfig(dataId, group, tenant string, timeout uint64,
 	}
 
 	if response.GetErrorCode() == 300 {
-		cache.WriteConfigToFile(cacheKey, cp.clientConfig.CacheDir, "")
-		cache.WriteEncryptedDataKeyToFile(cacheKey, cp.clientConfig.CacheDir, "")
+		err = cache.WriteConfigToFile(cacheKey, cp.clientConfig.CacheDir, "")
+		if err != nil {
+			return nil, err
+		}
+		err = cache.WriteEncryptedDataKeyToFile(cacheKey, cp.clientConfig.CacheDir, "")
+		if err != nil {
+			return nil, err
+		}
 		response.SetSuccess(true)
 		return response, nil
 	}


### PR DESCRIPTION
This picks up four unhandled `err` variables in `clients/config_client`.