### PR TITLE
fix #883 improve gRPC address normalization for edge cases

### DIFF
--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strconv"
@@ -96,22 +95,24 @@ func getInitialConnWindowSize() int32 {
 	return int32(initialConnWindowSize)
 }
 
-func getTLSCredentials(tlsConfig *constant.TLSConfig, serverInfo ServerInfo) credentials.TransportCredentials {
-
-	logger.Infof("build tls config for connecting to server %s,tlsConfig = %s", serverInfo.serverIp, tlsConfig)
+func getTLSCredentials(tlsConfig *constant.TLSConfig, serverInfo ServerInfo) (credentials.TransportCredentials, error) {
+	logger.Infof("build tls config for connecting to server %s, tlsConfig = %+v", serverInfo.serverIp, tlsConfig)
 
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		log.Fatalf("load root cert pool fail : %v", err)
+		logger.Warnf("failed to load system cert pool: %v, using empty pool", err)
+		certPool = x509.NewCertPool()
 	}
+
 	if len(tlsConfig.CaFile) != 0 {
-		cert, err := os.ReadFile(tlsConfig.CaFile)
+		caCert, err := os.ReadFile(tlsConfig.CaFile)
 		if err != nil {
-			_ = fmt.Errorf("err, %v", err)
+			return nil, fmt.Errorf("failed to read CA file %q: %w", tlsConfig.CaFile, err)
 		}
-		if ok := certPool.AppendCertsFromPEM(cert); !ok {
-			_ = fmt.Errorf("failed to append ca certs")
+		if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+			return nil, fmt.Errorf("failed to parse CA certificates from %q", tlsConfig.CaFile)
 		}
+		logger.Infof("loaded custom CA certificates from %s", tlsConfig.CaFile)
 	}
 
 	config := tls.Config{
@@ -119,16 +120,22 @@ func getTLSCredentials(tlsConfig *constant.TLSConfig, serverInfo ServerInfo) cre
 		RootCAs:            certPool,
 		Certificates:       []tls.Certificate{},
 	}
+
+	if len(tlsConfig.ServerNameOverride) > 0 {
+		config.ServerName = tlsConfig.ServerNameOverride
+		logger.Infof("using server name override: %s", tlsConfig.ServerNameOverride)
+	}
+
 	if len(tlsConfig.CertFile) != 0 && len(tlsConfig.KeyFile) != 0 {
 		cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
-
 		if err != nil {
-			log.Fatalf("load cert fail : %v", err)
+			return nil, fmt.Errorf("failed to load client certificate (cert=%q, key=%q): %w", tlsConfig.CertFile, tlsConfig.KeyFile, err)
 		}
 		config.Certificates = append(config.Certificates, cert)
+		logger.Infof("loaded client certificate from %s", tlsConfig.CertFile)
 	}
-	transportCredentials := credentials.NewTLS(&config)
-	return transportCredentials
+
+	return credentials.NewTLS(&config), nil
 }
 
 func getInitialGrpcTimeout() int32 {
@@ -198,7 +205,11 @@ func (c *GrpcClient) createNewConnection(serverInfo ServerInfo) (*grpc.ClientCon
 	c.getEnvTLSConfig(c.TLSConfig)
 	if c.TLSConfig.Enable {
 		logger.Infof(" tls enable ,trying to connection to server %s with tls config %s", serverInfo.serverIp, c.TLSConfig)
-		opts = append(opts, grpc.WithTransportCredentials(getTLSCredentials(c.TLSConfig, serverInfo)))
+		creds, err := getTLSCredentials(c.TLSConfig, serverInfo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS credentials: %w", err)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -153,6 +154,41 @@ func getKeepAliveTimeMillis() keepalive.ClientParameters {
 	}
 }
 
+// resolveGrpcAddress normalizes serverIp into a proper gRPC target address.
+// It handles:
+//   - Stripping http:// or https:// scheme prefixes
+//   - Detecting IP vs domain name (including bracketed IPv6)
+//   - Applying dns:/// for domains, passthrough:/// for IPs
+//   - Adding brackets around bare IPv6 addresses for correct host:port formatting
+func resolveGrpcAddress(serverIp string, port uint64) string {
+	host := serverIp
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimPrefix(host, "https://")
+
+	// Determine if host is an IP address.
+	// net.ParseIP does not accept bracketed IPv6 like "[::1]",
+	// so we strip brackets before checking.
+	ip := net.ParseIP(host)
+	if ip == nil {
+		bare := strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+		if parsed := net.ParseIP(bare); parsed != nil {
+			ip = parsed
+			// Normalize to bracketed form for correct host:port formatting
+			host = "[" + bare + "]"
+		}
+	} else if strings.ContainsRune(host, ':') {
+		// Bare IPv6 or IPv4-mapped IPv6 (e.g. "::1", "::ffff:127.0.0.1")
+		// must add brackets for unambiguous host:port formatting
+		host = "[" + host + "]"
+	}
+
+	address := host + ":" + strconv.FormatUint(port, 10)
+	if ip != nil {
+		return "passthrough:///" + address
+	}
+	return "dns:///" + address
+}
+
 func (c *GrpcClient) createNewConnection(serverInfo ServerInfo) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(getMaxCallRecvMsgSize())))
@@ -170,14 +206,7 @@ func (c *GrpcClient) createNewConnection(serverInfo ServerInfo) (*grpc.ClientCon
 	if rpcPort == 0 {
 		rpcPort = serverInfo.serverPort + c.rpcPortOffset()
 	}
-	address := serverInfo.serverIp + ":" + strconv.FormatUint(rpcPort, 10)
-	// If serverIp is a domain name (not an IP), use the dns:/// scheme so gRPC
-	// resolves it via the DNS resolver instead of passthrough.
-	if net.ParseIP(serverInfo.serverIp) == nil {
-		address = "dns:///" + address
-	}
-	return grpc.NewClient(address, opts...)
-
+	return grpc.NewClient(resolveGrpcAddress(serverInfo.serverIp, rpcPort), opts...)
 }
 
 func (c *GrpcClient) getEnvTLSConfig(config *constant.TLSConfig) {

--- a/common/remote/rpc/grpc_client_integration_test.go
+++ b/common/remote/rpc/grpc_client_integration_test.go
@@ -1,0 +1,85 @@
+package rpc
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TestResolveGrpcAddressIntegration tests actual gRPC connectivity using resolveGrpcAddress.
+// It requires a local Nacos server running on 127.0.0.1:9848 (gRPC port).
+// Set NACOS_INTEGRATION_TEST=1 to enable these tests.
+func TestResolveGrpcAddressIntegration(t *testing.T) {
+	if os.Getenv("NACOS_INTEGRATION_TEST") != "1" {
+		t.Skip("Skipping integration test: set NACOS_INTEGRATION_TEST=1 to enable")
+	}
+
+	tests := []struct {
+		name     string
+		serverIp string
+		port     uint64
+		wantOK   bool
+	}{
+		// Should connect successfully
+		{"IPv4 direct", "127.0.0.1", 9848, true},
+		{"localhost domain", "localhost", 9848, true},
+		{"http prefix IPv4", "http://127.0.0.1", 9848, true},
+		{"http prefix localhost", "http://localhost", 9848, true},
+		{"bracketed IPv6 loopback", "[::1]", 9848, true},
+		{"bare IPv6 loopback", "::1", 9848, true},
+
+		// Should fail to connect (unreachable or invalid)
+		{"unreachable IP", "192.168.255.255", 9848, false},
+		{"non-existent domain", "this-host-does-not-exist.invalid", 9848, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address := resolveGrpcAddress(tt.serverIp, tt.port)
+			t.Logf("resolveGrpcAddress(%q, %d) = %q", tt.serverIp, tt.port, address)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			conn, err := grpc.NewClient(address,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				if tt.wantOK {
+					t.Fatalf("grpc.NewClient failed: %v", err)
+				}
+				return
+			}
+			defer conn.Close()
+
+			conn.Connect()
+
+			connected := false
+			for {
+				state := conn.GetState()
+				if state == connectivity.Ready {
+					connected = true
+					break
+				}
+				if state == connectivity.TransientFailure || state == connectivity.Shutdown {
+					break
+				}
+				if !conn.WaitForStateChange(ctx, state) {
+					break
+				}
+			}
+
+			if tt.wantOK && !connected {
+				t.Errorf("Expected successful connection for %q, but failed (target=%q)", tt.serverIp, address)
+			}
+			if !tt.wantOK && connected {
+				t.Errorf("Expected connection failure for %q, but succeeded (target=%q)", tt.serverIp, address)
+			}
+		})
+	}
+}

--- a/common/remote/rpc/grpc_client_test.go
+++ b/common/remote/rpc/grpc_client_test.go
@@ -1,6 +1,20 @@
 package rpc
 
-import "testing"
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
+)
 
 func TestResolveGrpcAddress(t *testing.T) {
 	tests := []struct {
@@ -148,4 +162,239 @@ func TestResolveGrpcAddress(t *testing.T) {
 			}
 		})
 	}
+}
+
+// generateTestCerts creates a self-signed CA cert and a client cert/key pair for testing.
+// Returns paths to: caFile, certFile, keyFile
+func generateTestCerts(t *testing.T, dir string) (string, string, string) {
+	t.Helper()
+
+	// Generate CA key and cert
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Test CA"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caFile := filepath.Join(dir, "ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+	if err := os.WriteFile(caFile, caPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate client key and cert signed by CA
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{Organization: []string{"Test Client"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certFile := filepath.Join(dir, "client.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+	if err := os.WriteFile(certFile, certPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	keyFile := filepath.Join(dir, "client-key.pem")
+	keyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyFile, keyPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return caFile, certFile, keyFile
+}
+
+func TestGetTLSCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+	caFile, certFile, keyFile := generateTestCerts(t, tmpDir)
+
+	// Create an invalid PEM file (not valid certificate data)
+	invalidPEMFile := filepath.Join(tmpDir, "invalid.pem")
+	if err := os.WriteFile(invalidPEMFile, []byte("not a valid PEM"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	serverInfo := ServerInfo{serverIp: "127.0.0.1", serverPort: 8848}
+
+	tests := []struct {
+		name      string
+		tlsConfig *constant.TLSConfig
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "no CA, no client cert, TrustAll=true",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				TrustAll: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no CA, no client cert, TrustAll=false (use system CA pool)",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				TrustAll: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid CA file",
+			tlsConfig: &constant.TLSConfig{
+				Enable: true,
+				CaFile: caFile,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid CA + valid client cert",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				CaFile:   caFile,
+				CertFile: certFile,
+				KeyFile:  keyFile,
+			},
+			wantErr: false,
+		},
+		{
+			name: "non-existent CA file",
+			tlsConfig: &constant.TLSConfig{
+				Enable: true,
+				CaFile: "/non/existent/ca.pem",
+			},
+			wantErr: true,
+			errMsg:  "failed to read CA file",
+		},
+		{
+			name: "invalid PEM in CA file",
+			tlsConfig: &constant.TLSConfig{
+				Enable: true,
+				CaFile: invalidPEMFile,
+			},
+			wantErr: true,
+			errMsg:  "failed to parse CA certificates",
+		},
+		{
+			name: "non-existent client cert file",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				CertFile: "/non/existent/cert.pem",
+				KeyFile:  keyFile,
+			},
+			wantErr: true,
+			errMsg:  "failed to load client certificate",
+		},
+		{
+			name: "non-existent client key file",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				CertFile: certFile,
+				KeyFile:  "/non/existent/key.pem",
+			},
+			wantErr: true,
+			errMsg:  "failed to load client certificate",
+		},
+		{
+			name: "mismatched cert and key",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				CertFile: caFile,
+				KeyFile:  keyFile,
+			},
+			wantErr: true,
+			errMsg:  "failed to load client certificate",
+		},
+		{
+			name: "ServerNameOverride set",
+			tlsConfig: &constant.TLSConfig{
+				Enable:             true,
+				TrustAll:           true,
+				ServerNameOverride: "nacos.example.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "only CertFile without KeyFile (should skip client cert)",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				TrustAll: true,
+				CertFile: certFile,
+			},
+			wantErr: false,
+		},
+		{
+			name: "only KeyFile without CertFile (should skip client cert)",
+			tlsConfig: &constant.TLSConfig{
+				Enable:   true,
+				TrustAll: true,
+				KeyFile:  keyFile,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := getTLSCredentials(tt.tlsConfig, serverInfo)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMsg)
+					return
+				}
+				if tt.errMsg != "" && !containsStr(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+				if creds != nil {
+					t.Error("expected nil credentials on error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if creds == nil {
+					t.Error("expected non-nil credentials")
+				}
+			}
+		})
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && contains(s, substr))
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/common/remote/rpc/grpc_client_test.go
+++ b/common/remote/rpc/grpc_client_test.go
@@ -1,0 +1,151 @@
+package rpc
+
+import "testing"
+
+func TestResolveGrpcAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		serverIp string
+		port     uint64
+		want     string
+	}{
+		// IPv4 cases
+		{
+			name:     "IPv4 address",
+			serverIp: "127.0.0.1",
+			port:     9848,
+			want:     "passthrough:///127.0.0.1:9848",
+		},
+		{
+			name:     "IPv4 private address",
+			serverIp: "10.0.0.1",
+			port:     9848,
+			want:     "passthrough:///10.0.0.1:9848",
+		},
+		{
+			name:     "IPv4 with different port",
+			serverIp: "192.168.1.100",
+			port:     19848,
+			want:     "passthrough:///192.168.1.100:19848",
+		},
+
+		// IPv6 cases
+		{
+			name:     "bare IPv6 loopback",
+			serverIp: "::1",
+			port:     9848,
+			want:     "passthrough:///[::1]:9848",
+		},
+		{
+			name:     "bracketed IPv6 loopback",
+			serverIp: "[::1]",
+			port:     9848,
+			want:     "passthrough:///[::1]:9848",
+		},
+		{
+			name:     "bare IPv6 full address",
+			serverIp: "2001:db8::1",
+			port:     9848,
+			want:     "passthrough:///[2001:db8::1]:9848",
+		},
+		{
+			name:     "bracketed IPv6 full address",
+			serverIp: "[2001:db8::1]",
+			port:     9848,
+			want:     "passthrough:///[2001:db8::1]:9848",
+		},
+		{
+			name:     "IPv4-mapped IPv6",
+			serverIp: "::ffff:127.0.0.1",
+			port:     9848,
+			want:     "passthrough:///[::ffff:127.0.0.1]:9848",
+		},
+		{
+			name:     "bracketed IPv4-mapped IPv6",
+			serverIp: "[::ffff:127.0.0.1]",
+			port:     9848,
+			want:     "passthrough:///[::ffff:127.0.0.1]:9848",
+		},
+
+		// Domain name cases
+		{
+			name:     "localhost domain",
+			serverIp: "localhost",
+			port:     9848,
+			want:     "dns:///localhost:9848",
+		},
+		{
+			name:     "FQDN domain",
+			serverIp: "nacos.example.com",
+			port:     9848,
+			want:     "dns:///nacos.example.com:9848",
+		},
+		{
+			name:     "Kubernetes service domain",
+			serverIp: "nacos-server.nacos.svc.cluster.local",
+			port:     9848,
+			want:     "dns:///nacos-server.nacos.svc.cluster.local:9848",
+		},
+
+		// http:// prefix cases (user misconfiguration)
+		{
+			name:     "http prefix with IPv4",
+			serverIp: "http://127.0.0.1",
+			port:     9848,
+			want:     "passthrough:///127.0.0.1:9848",
+		},
+		{
+			name:     "http prefix with domain",
+			serverIp: "http://nacos.example.com",
+			port:     9848,
+			want:     "dns:///nacos.example.com:9848",
+		},
+		{
+			name:     "http prefix with localhost",
+			serverIp: "http://localhost",
+			port:     9848,
+			want:     "dns:///localhost:9848",
+		},
+		{
+			name:     "https prefix with IPv4",
+			serverIp: "https://10.0.0.1",
+			port:     9848,
+			want:     "passthrough:///10.0.0.1:9848",
+		},
+		{
+			name:     "https prefix with domain",
+			serverIp: "https://nacos.example.com",
+			port:     9848,
+			want:     "dns:///nacos.example.com:9848",
+		},
+		{
+			name:     "http prefix with bracketed IPv6",
+			serverIp: "http://[::1]",
+			port:     9848,
+			want:     "passthrough:///[::1]:9848",
+		},
+
+		// Edge cases
+		{
+			name:     "empty string defaults to dns",
+			serverIp: "",
+			port:     9848,
+			want:     "dns:///:9848",
+		},
+		{
+			name:     "port zero",
+			serverIp: "127.0.0.1",
+			port:     0,
+			want:     "passthrough:///127.0.0.1:0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveGrpcAddress(tt.serverIp, tt.port)
+			if got != tt.want {
+				t.Errorf("resolveGrpcAddress(%q, %d) = %q, want %q", tt.serverIp, tt.port, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses all four follow-up issues identified in #883 after PR #875 was merged:

1. **Strip http:// and https:// scheme prefixes** — `nacos_server.go`'s `getAddress()` only handles scheme for HTTP REST; gRPC layer now strips scheme before address resolution
2. **Use explicit passthrough:/// for IP addresses** — `grpc.NewClient` defaults to dns resolver, which is unnecessary for raw IPs
3. **Handle bare/bracketed IPv6 correctly** — adds brackets around IPv6 addresses for proper host:port formatting
4. **Fix getTLSCredentials error handling** — replace `log.Fatalf` (kills process) and dead code `_ = fmt.Errorf(...)` with proper error propagation; add ServerNameOverride support

## Changes

### Commit 1: gRPC address normalization
- Extract `resolveGrpcAddress` function for centralized target address construction
- Strip scheme prefixes, detect IP vs domain, apply proper gRPC resolver scheme
- Add brackets around bare IPv6 (including IPv4-mapped IPv6 like `::ffff:127.0.0.1`)

### Commit 2: TLS error handling
- Change `getTLSCredentials` signature to return `(credentials.TransportCredentials, error)`
- Replace `log.Fatalf` with error returns (SDK library should never kill the host process)
- Replace dead code `_ = fmt.Errorf(...)` with proper `return nil, fmt.Errorf(...)`
- Add `ServerNameOverride` support from TLSConfig (was previously ignored)
- Graceful fallback: system cert pool failure logs warning and uses empty pool
- Add informative log messages for certificate loading operations

## Test plan

- [x] Unit tests: 21 cases for `resolveGrpcAddress` (IPv4, IPv6, domains, scheme prefixes, edge cases)
- [x] Unit tests: 12 cases for `getTLSCredentials` (valid certs, invalid paths, invalid PEM, mismatched keys, ServerNameOverride)
- [x] Integration tests: 8 cases with real gRPC connections to local Nacos
- [x] Full regression: `go test ./...` passes with zero failures
- [x] `go vet ./common/remote/rpc/...` clean

## Behavioral comparison (address resolution)

| Input serverIp | Before (PR #875) | After (this PR) |
|---|---|---|
| `127.0.0.1` | `127.0.0.1:9848` (implicit dns) | `passthrough:///127.0.0.1:9848` |
| `localhost` | `dns:///localhost:9848` | `dns:///localhost:9848` |
| `::1` | `::1:9848` (ambiguous, fails) | `passthrough:///[::1]:9848` |
| `[::1]` | `dns:///[::1]:9848` (misclassified) | `passthrough:///[::1]:9848` |
| `http://127.0.0.1` | `dns:///http://127.0.0.1:9848` (hangs) | `passthrough:///127.0.0.1:9848` |
| `http://localhost` | `dns:///http://localhost:9848` (hangs) | `dns:///localhost:9848` |

## TLS error handling comparison

| Scenario | Before | After |
|---|---|---|
| System cert pool fails | `log.Fatalf` → process killed | Warning log + empty pool fallback |
| CA file not found | Error silently discarded | `return nil, err` → connection fails with clear message |
| Invalid PEM in CA file | Error silently discarded | `return nil, err` → clear error message |
| Client cert load fails | `log.Fatalf` → process killed | `return nil, err` → propagated to caller |
| ServerNameOverride configured | Ignored | Applied to `tls.Config.ServerName` |

Closes #883