### PR TITLE
fix #868: validate serviceName to prevent client UNHEALTHY cascade

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -157,6 +157,9 @@ func (sc *NamingClient) BatchRegisterInstance(param vo.BatchRegisterInstancePara
 
 // DeregisterInstance ...
 func (sc *NamingClient) DeregisterInstance(param vo.DeregisterInstanceParam) (bool, error) {
+	if param.ServiceName == "" {
+		return false, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -197,6 +200,9 @@ func (sc *NamingClient) UpdateInstance(param vo.UpdateInstanceParam) (bool, erro
 
 // GetService Get service info by Group and DataId, clusters was optional
 func (sc *NamingClient) GetService(param vo.GetServiceParam) (service model.Service, err error) {
+	if param.ServiceName == "" {
+		return model.Service{}, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -231,6 +237,9 @@ func (sc *NamingClient) GetAllServicesInfo(param vo.GetAllServiceInfoParam) (mod
 
 // SelectAllInstances Get all instance by DataId 和 Group
 func (sc *NamingClient) SelectAllInstances(param vo.SelectAllInstancesParam) ([]model.Instance, error) {
+	if param.ServiceName == "" {
+		return nil, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -256,6 +265,9 @@ func (sc *NamingClient) SelectAllInstances(param vo.SelectAllInstancesParam) ([]
 
 // SelectInstances Get all instance by DataId, Group and Health
 func (sc *NamingClient) SelectInstances(param vo.SelectInstancesParam) ([]model.Instance, error) {
+	if param.ServiceName == "" {
+		return nil, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -293,6 +305,9 @@ func (sc *NamingClient) selectInstances(service model.Service, healthy bool) ([]
 
 // SelectOneHealthyInstance Get one healthy instance by DataId and Group
 func (sc *NamingClient) SelectOneHealthyInstance(param vo.SelectOneHealthInstanceParam) (*model.Instance, error) {
+	if param.ServiceName == "" {
+		return nil, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -339,6 +354,9 @@ func (sc *NamingClient) selectOneHealthyInstances(service model.Service) (*model
 
 // Subscribe ...
 func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
+	if param.ServiceName == "" {
+		return errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -351,6 +369,9 @@ func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
 
 // Unsubscribe ...
 func (sc *NamingClient) Unsubscribe(param *vo.SubscribeParam) (err error) {
+	if param.ServiceName == "" {
+		return errors.New("serviceName cannot be empty!")
+	}
 	clusterSelector := naming_cache.NewClusterSelector(param.Clusters)
 	callbackWrapper := naming_cache.NewSubscribeCallbackFuncWrapper(clusterSelector, &param.SubscribeCallback)
 	serviceFullName := util.GetGroupName(param.ServiceName, param.GroupName)

--- a/clients/naming_client/naming_client_test.go
+++ b/clients/naming_client/naming_client_test.go
@@ -457,6 +457,74 @@ func BenchmarkNamingClient_SelectOneHealthyInstances(b *testing.B) {
 
 }
 
+func TestNamingClient_Subscribe_EmptyServiceName(t *testing.T) {
+	callback := func(services []model.Instance, err error) {}
+	err := NewTestNamingClient().Subscribe(&vo.SubscribeParam{
+		ServiceName:       "",
+		GroupName:         "DEFAULT_GROUP",
+		SubscribeCallback: callback,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_Unsubscribe_EmptyServiceName(t *testing.T) {
+	callback := func(services []model.Instance, err error) {}
+	err := NewTestNamingClient().Unsubscribe(&vo.SubscribeParam{
+		ServiceName:       "",
+		GroupName:         "DEFAULT_GROUP",
+		SubscribeCallback: callback,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_DeregisterInstance_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().DeregisterInstance(vo.DeregisterInstanceParam{
+		ServiceName: "",
+		Ip:          "10.0.0.10",
+		Port:        80,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_GetService_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().GetService(vo.GetServiceParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_SelectAllInstances_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().SelectAllInstances(vo.SelectAllInstancesParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_SelectInstances_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().SelectInstances(vo.SelectInstancesParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_SelectOneHealthyInstance_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().SelectOneHealthyInstance(vo.SelectOneHealthInstanceParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
 func TestNamingClient_Unsubscribe_WithCallback_ShouldNotCallServiceProxyUnsubscribe(t *testing.T) {
 	// 创建一个带有回调函数的订阅参数
 	callback := func(services []model.Instance, err error) {


### PR DESCRIPTION
## What is the purpose of the change

When `serviceName` is empty, the Nacos server returns a 500 error (`Param 'serviceName' is illegal, serviceName is blank`). The SDK misclassifies this business error as a connectivity issue, causing:

1. Retry exhaustion (3 retries all fail with the same 500)
2. Client status changed from RUNNING → UNHEALTHY
3. `switchServerAsync` triggers reconnection
4. `OnConnected` → `redoSubscribe` retries the invalid subscription (cached before request)
5. Loop back to step 1 — **all other healthy subscriptions on the same client are affected**

## Brief changelog

Add `serviceName` empty validation at the `NamingClient` entry layer for:

- `Subscribe`
- `Unsubscribe`
- `DeregisterInstance`
- `GetService`
- `SelectAllInstances`
- `SelectInstances`
- `SelectOneHealthyInstance`

This is consistent with the existing validation pattern already present in `RegisterInstance`, `BatchRegisterInstance`, and `UpdateInstance`.

## How to verify

Added 7 unit test cases covering all validated methods:

```
go test ./clients/naming_client/ -v -run "EmptyServiceName"
```

All 21 tests in the package pass (including existing tests).