### PR TITLE
fix: remove duplicate credentials import introduced by #852

### DIFF
--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -31,8 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"google.golang.org/grpc/credentials"
-
 	"github.com/pkg/errors"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_request"


### PR DESCRIPTION
#852 moved the `google.golang.org/grpc/credentials` import from the stdlib block to a separate third-party group, but the same import already existed in the main third-party import block (L46). The squash merge did not conflict because the two occurrences were in different import groups, resulting in a duplicate declaration that breaks compilation:

```
grpc_client.go:46:2: credentials redeclared in this block
grpc_client.go:34:2: other declaration of credentials
```

This removes the redundant import at L34, keeping the one alongside other `google.golang.org/grpc/*` packages.