### PR TITLE
fix #892: refresh naming disk cache asynchronously

### DIFF
--- a/clients/cache/disk_cache.go
+++ b/clients/cache/disk_cache.go
@@ -56,17 +56,24 @@ func GetConfigFailOverEncryptedDataKeyFileName(cacheKey, cacheDir string) string
 }
 
 func WriteServicesToFile(service *model.Service, cacheKey, cacheDir string) {
+	WriteServicesToFileWithResult(service, cacheKey, cacheDir)
+}
+
+// WriteServicesToFileWithResult writes service info to disk and returns whether the write succeeds.
+func WriteServicesToFileWithResult(service *model.Service, cacheKey, cacheDir string) bool {
 	err := file.MkdirIfNecessary(cacheDir)
 	if err != nil {
 		logger.Errorf("mkdir cacheDir failed,cacheDir:%s,err:", cacheDir, err)
-		return
+		return false
 	}
 	bytes, _ := json.Marshal(service)
 	domFileName := GetFileName(cacheKey, cacheDir)
 	err = os.WriteFile(domFileName, bytes, 0666)
 	if err != nil {
 		logger.Errorf("failed to write name cache:%s ,value:%s ,err:%v", domFileName, string(bytes), err)
+		return false
 	}
+	return true
 }
 
 func ReadServicesFromFile(cacheDir string) map[string]model.Service {

--- a/clients/naming_client/naming_cache/service_info_disk_cache_refresher.go
+++ b/clients/naming_client/naming_cache/service_info_disk_cache_refresher.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package naming_cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
+	"github.com/nacos-group/nacos-sdk-go/v2/model"
+)
+
+const (
+	defaultDiskCacheFlushInterval   = 100 * time.Millisecond
+	defaultDiskCacheShutdownTimeout = 3 * time.Second
+)
+
+type diskCacheWriter func(service *model.Service, cacheKey, cacheDir string) bool
+
+type serviceInfoDiskCacheRefreshEvent struct {
+	service  *model.Service
+	cacheKey string
+	cacheDir string
+}
+
+type serviceInfoDiskCacheRefresher struct {
+	mux             sync.Mutex
+	pendingEvents   map[string]*serviceInfoDiskCacheRefreshEvent
+	writer          diskCacheWriter
+	ticker          *time.Ticker
+	stopCh          chan struct{}
+	doneCh          chan struct{}
+	shutdownTimeout time.Duration
+	closed          bool
+	closeOnce       sync.Once
+}
+
+func newServiceInfoDiskCacheRefresher(flushInterval time.Duration, writer diskCacheWriter) *serviceInfoDiskCacheRefresher {
+	refresher := &serviceInfoDiskCacheRefresher{
+		pendingEvents:   make(map[string]*serviceInfoDiskCacheRefreshEvent),
+		writer:          writer,
+		ticker:          time.NewTicker(flushInterval),
+		stopCh:          make(chan struct{}),
+		doneCh:          make(chan struct{}),
+		shutdownTimeout: defaultDiskCacheShutdownTimeout,
+	}
+	go refresher.run()
+	return refresher
+}
+
+func (r *serviceInfoDiskCacheRefresher) publish(event *serviceInfoDiskCacheRefreshEvent) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	if r.closed {
+		return
+	}
+	r.pendingEvents[event.cacheKey] = event
+}
+
+func (r *serviceInfoDiskCacheRefresher) pendingEventSize() int {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	return len(r.pendingEvents)
+}
+
+func (r *serviceInfoDiskCacheRefresher) close() {
+	r.closeOnce.Do(func() {
+		r.mux.Lock()
+		r.closed = true
+		r.mux.Unlock()
+		close(r.stopCh)
+		select {
+		case <-r.doneCh:
+		case <-time.After(r.shutdownTimeout):
+			logger.Warnf("timeout while waiting service info disk cache refresher to close, pending event size:%d", r.pendingEventSize())
+		}
+	})
+}
+
+func (r *serviceInfoDiskCacheRefresher) run() {
+	defer close(r.doneCh)
+	defer r.ticker.Stop()
+	for {
+		select {
+		case <-r.ticker.C:
+			r.safeFlushPendingEvents()
+		case <-r.stopCh:
+			r.safeFlushPendingEvents()
+			return
+		}
+	}
+}
+
+func (r *serviceInfoDiskCacheRefresher) safeFlushPendingEvents() {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Errorf("failed to flush service info disk cache refresh event, err:%v", err)
+		}
+	}()
+	r.flushPendingEvents()
+}
+
+func (r *serviceInfoDiskCacheRefresher) flushPendingEvents() {
+	r.mux.Lock()
+	events := make([]*serviceInfoDiskCacheRefreshEvent, 0, len(r.pendingEvents))
+	for _, event := range r.pendingEvents {
+		events = append(events, event)
+	}
+	r.mux.Unlock()
+
+	for _, event := range events {
+		if r.writer(event.service, event.cacheKey, event.cacheDir) {
+			r.mux.Lock()
+			if r.pendingEvents[event.cacheKey] == event {
+				delete(r.pendingEvents, event.cacheKey)
+			}
+			r.mux.Unlock()
+		}
+	}
+}

--- a/clients/naming_client/naming_cache/service_info_holder.go
+++ b/clients/naming_client/naming_cache/service_info_holder.go
@@ -38,6 +38,7 @@ type ServiceInfoHolder struct {
 	notLoadCacheAtStart  bool
 	subCallback          *SubscribeCallback
 	UpdateTimeMap        sync.Map
+	diskCacheRefresher   *serviceInfoDiskCacheRefresher
 }
 
 func NewServiceInfoHolder(namespace, cacheDir string, updateCacheWhenEmpty, notLoadCacheAtStart bool) *ServiceInfoHolder {
@@ -49,6 +50,7 @@ func NewServiceInfoHolder(namespace, cacheDir string, updateCacheWhenEmpty, notL
 		subCallback:          NewSubscribeCallback(),
 		UpdateTimeMap:        sync.Map{},
 		ServiceInfoMap:       sync.Map{},
+		diskCacheRefresher:   newServiceInfoDiskCacheRefresher(defaultDiskCacheFlushInterval, cache.WriteServicesToFileWithResult),
 	}
 
 	if !notLoadCacheAtStart {
@@ -94,7 +96,7 @@ func (s *ServiceInfoHolder) ProcessService(service *model.Service) {
 	s.ServiceInfoMap.Store(cacheKey, *service)
 	if !ok || checkInstanceChanged(oldDomain, *service) {
 		logger.Infof("service key:%s was updated to:%s", cacheKey, util.ToJsonString(service))
-		cache.WriteServicesToFile(service, cacheKey, s.cacheDir)
+		s.refreshDiskCache(service, cacheKey)
 		s.subCallback.ServiceChanged(cacheKey, service)
 	}
 	var count int
@@ -130,6 +132,43 @@ func (s *ServiceInfoHolder) StopUpdateIfContain(serviceName, clusters string) {
 
 func (s *ServiceInfoHolder) IsSubscribed(serviceName, clusters string) bool {
 	return s.subCallback.IsSubscribed(serviceName, clusters)
+}
+
+func (s *ServiceInfoHolder) Close() {
+	if s.diskCacheRefresher != nil {
+		s.diskCacheRefresher.close()
+	}
+}
+
+func (s *ServiceInfoHolder) refreshDiskCache(service *model.Service, cacheKey string) {
+	if s.diskCacheRefresher == nil {
+		return
+	}
+	s.diskCacheRefresher.publish(&serviceInfoDiskCacheRefreshEvent{
+		service:  cloneService(service),
+		cacheKey: cacheKey,
+		cacheDir: s.cacheDir,
+	})
+}
+
+func cloneService(service *model.Service) *model.Service {
+	if service == nil {
+		return nil
+	}
+	cloned := *service
+	if service.Hosts != nil {
+		cloned.Hosts = make([]model.Instance, len(service.Hosts))
+		for i, instance := range service.Hosts {
+			cloned.Hosts[i] = instance
+			if instance.Metadata != nil {
+				cloned.Hosts[i].Metadata = make(map[string]string, len(instance.Metadata))
+				for key, value := range instance.Metadata {
+					cloned.Hosts[i].Metadata[key] = value
+				}
+			}
+		}
+	}
+	return &cloned
 }
 
 func checkInstanceChanged(oldDomain interface{}, service model.Service) bool {

--- a/clients/naming_client/naming_cache/service_info_holder_test.go
+++ b/clients/naming_client/naming_cache/service_info_holder_test.go
@@ -18,11 +18,13 @@ package naming_cache
 import (
 	"fmt"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
 	"github.com/nacos-group/nacos-sdk-go/v2/model"
+	"github.com/nacos-group/nacos-sdk-go/v2/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,6 +143,124 @@ func TestHostReactor_isServiceInstanceChangedWithUnOrdered(t *testing.T) {
 	assert.True(t, changed)
 }
 
+func TestServiceInfoDiskCacheRefresherKeepsLatestSnapshot(t *testing.T) {
+	writeCount := 0
+	writtenServices := map[string]*model.Service{}
+	refresher := newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		writeCount++
+		writtenServices[cacheKey] = service
+		return true
+	})
+	defer refresher.close()
+
+	cacheKey := "DEFAULT_GROUP@@svc"
+	first := newTestService("svc", "1.1.1.1", 1)
+	second := newTestService("svc", "1.1.1.2", 2)
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{service: first, cacheKey: cacheKey, cacheDir: "cache"})
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{service: second, cacheKey: cacheKey, cacheDir: "cache"})
+
+	refresher.flushPendingEvents()
+
+	assert.Equal(t, 1, writeCount)
+	assert.Equal(t, "1.1.1.2", writtenServices[cacheKey].Hosts[0].Ip)
+	assert.Equal(t, 0, refresher.pendingEventSize())
+}
+
+func TestServiceInfoDiskCacheRefresherRetriesFailedWrite(t *testing.T) {
+	attempts := 0
+	refresher := newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		attempts++
+		return attempts > 1
+	})
+	defer refresher.close()
+
+	cacheKey := "DEFAULT_GROUP@@svc"
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{service: newTestService("svc", "1.1.1.1", 1), cacheKey: cacheKey, cacheDir: "cache"})
+
+	refresher.flushPendingEvents()
+
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, 1, refresher.pendingEventSize())
+
+	refresher.flushPendingEvents()
+
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, 0, refresher.pendingEventSize())
+}
+
+func TestServiceInfoDiskCacheRefresherCloseTimeout(t *testing.T) {
+	writerStarted := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	refresher := newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		close(writerStarted)
+		<-releaseWriter
+		return true
+	})
+	refresher.shutdownTimeout = 10 * time.Millisecond
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{
+		service:  newTestService("svc", "1.1.1.1", 1),
+		cacheKey: "DEFAULT_GROUP@@svc",
+		cacheDir: "cache",
+	})
+
+	closeReturned := make(chan struct{})
+	go func() {
+		refresher.close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-writerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("writer was not started")
+	}
+	select {
+	case <-closeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("close did not return after shutdown timeout")
+	}
+
+	close(releaseWriter)
+	select {
+	case <-refresher.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("refresher did not stop after writer was released")
+	}
+}
+
+func TestServiceInfoHolderProcessServiceQueuesDiskCacheBeforeCallback(t *testing.T) {
+	var writeCount int32
+	writtenIp := ""
+	holder := NewServiceInfoHolder("public", t.TempDir(), true, true)
+	holder.diskCacheRefresher.close()
+	holder.diskCacheRefresher = newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		atomic.AddInt32(&writeCount, 1)
+		writtenIp = service.Hosts[0].Ip
+		return true
+	})
+
+	service := newTestService("svc", "1.1.1.1", 1)
+	callbackCalled := false
+	callback := func(services []model.Instance, err error) {
+		callbackCalled = true
+		assert.Equal(t, int32(0), atomic.LoadInt32(&writeCount))
+		services[0].Ip = "callback-mutated"
+	}
+	callbackWrapper := NewSubscribeCallbackFuncWrapper(NewClusterSelector(nil), &callback)
+	holder.RegisterCallback(util.GetGroupName(service.Name, service.GroupName), "", callbackWrapper)
+
+	holder.ProcessService(service)
+
+	assert.True(t, callbackCalled)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&writeCount))
+	assert.Equal(t, 1, holder.diskCacheRefresher.pendingEventSize())
+
+	holder.Close()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&writeCount))
+	assert.Equal(t, "1.1.1.1", writtenIp)
+}
+
 // create random ip addr
 func createRandomIp() string {
 	ip := fmt.Sprintf("%d.%d.%d.%d", rand.Intn(255), rand.Intn(255), rand.Intn(255), rand.Intn(255))
@@ -149,4 +269,19 @@ func createRandomIp() string {
 
 func creatRandomPort() uint64 {
 	return rand.Uint64()
+}
+
+func newTestService(serviceName, ip string, lastRefTime uint64) *model.Service {
+	return &model.Service{
+		Name:        serviceName,
+		GroupName:   "DEFAULT_GROUP",
+		LastRefTime: lastRefTime,
+		Hosts: []model.Instance{
+			{
+				Ip:       ip,
+				Port:     8848,
+				Metadata: map[string]string{"k": "v"},
+			},
+		},
+	}
 }

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -87,11 +87,14 @@ func NewNamingClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 
 	naming.serviceProxy, err = NewNamingProxyDelegateWithRamCredentialProvider(ctx, clientConfig, serverConfig, httpAgent, naming.serviceInfoHolder, provider)
 
+	if err != nil {
+		cancel()
+		naming.serviceInfoHolder.Close()
+		return naming, err
+	}
+
 	if clientConfig.AsyncUpdateService {
 		go NewServiceInfoUpdater(ctx, naming.serviceInfoHolder, clientConfig.UpdateThreadNum, naming.serviceProxy).asyncUpdateService()
-	}
-	if err != nil {
-		return naming, err
 	}
 
 	return naming, nil
@@ -397,6 +400,9 @@ func (sc *NamingClient) CloseClient() {
 		return
 	}
 	sc.serviceProxy.CloseClient()
+	if sc.serviceInfoHolder != nil {
+		sc.serviceInfoHolder.Close()
+	}
 	sc.cancel()
 	sc.isClosed = true
 }


### PR DESCRIPTION
## Summary
- make naming service disk cache refresh asynchronous and coalesce repeated updates by cache key
- flush pending disk cache updates when the naming client closes
- keep the existing disk cache write API and add a result-returning writer for retry logic

## Related Issue
Fixes #892

## Testing
- go test ./clients/cache ./clients/naming_client/... -count=1
- go test ./...
- local Nacos smoke test: subscribe service, register instance, receive push, and verify async disk cache file is written