### PR TITLE
chore: sync master into v3.x-dev

### DIFF
--- a/clients/cache/disk_cache.go
+++ b/clients/cache/disk_cache.go
@@ -56,17 +56,24 @@ func GetConfigFailOverEncryptedDataKeyFileName(cacheKey, cacheDir string) string
 }
 
 func WriteServicesToFile(service *model.Service, cacheKey, cacheDir string) {
+	WriteServicesToFileWithResult(service, cacheKey, cacheDir)
+}
+
+// WriteServicesToFileWithResult writes service info to disk and returns whether the write succeeds.
+func WriteServicesToFileWithResult(service *model.Service, cacheKey, cacheDir string) bool {
 	err := file.MkdirIfNecessary(cacheDir)
 	if err != nil {
 		logger.Errorf("mkdir cacheDir failed,cacheDir:%s,err:", cacheDir, err)
-		return
+		return false
 	}
 	bytes, _ := json.Marshal(service)
 	domFileName := GetFileName(cacheKey, cacheDir)
 	err = os.WriteFile(domFileName, bytes, 0666)
 	if err != nil {
 		logger.Errorf("failed to write name cache:%s ,value:%s ,err:%v", domFileName, string(bytes), err)
+		return false
 	}
+	return true
 }
 
 func ReadServicesFromFile(cacheDir string) map[string]model.Service {

--- a/clients/client_factory.go
+++ b/clients/client_factory.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/nacos_client"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/http_agent"
+	"github.com/nacos-group/nacos-sdk-go/v2/util"
 	"github.com/nacos-group/nacos-sdk-go/v2/vo"
 )
 
@@ -93,6 +94,9 @@ func setConfig(param vo.NacosClientParam) (iClient nacos_client.INacosClient, er
 		err = client.SetClientConfig(*param.ClientConfig)
 		if err != nil {
 			return nil, err
+		}
+		if param.ClientConfig.ClientIP != "" {
+			util.SetClientIPFromConfig(param.ClientConfig.ClientIP)
 		}
 	}
 

--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -111,6 +111,10 @@ func NewConfigClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 	if err != nil {
 		return nil, err
 	}
+	// Set custom client IP if configured
+	if clientConfig.ClientIP != "" {
+		util.SetCustomClientIP(clientConfig.ClientIP)
+	}
 	serverConfig, err := nc.GetServerConfig()
 	if err != nil {
 		return nil, err

--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -111,10 +111,6 @@ func NewConfigClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 	if err != nil {
 		return nil, err
 	}
-	// Set custom client IP if configured
-	if clientConfig.ClientIP != "" {
-		util.SetCustomClientIP(clientConfig.ClientIP)
-	}
 	serverConfig, err := nc.GetServerConfig()
 	if err != nil {
 		return nil, err

--- a/clients/naming_client/naming_cache/service_info_disk_cache_refresher.go
+++ b/clients/naming_client/naming_cache/service_info_disk_cache_refresher.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package naming_cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
+	"github.com/nacos-group/nacos-sdk-go/v2/model"
+)
+
+const (
+	defaultDiskCacheFlushInterval   = 100 * time.Millisecond
+	defaultDiskCacheShutdownTimeout = 3 * time.Second
+)
+
+type diskCacheWriter func(service *model.Service, cacheKey, cacheDir string) bool
+
+type serviceInfoDiskCacheRefreshEvent struct {
+	service  *model.Service
+	cacheKey string
+	cacheDir string
+}
+
+type serviceInfoDiskCacheRefresher struct {
+	mux             sync.Mutex
+	pendingEvents   map[string]*serviceInfoDiskCacheRefreshEvent
+	writer          diskCacheWriter
+	ticker          *time.Ticker
+	stopCh          chan struct{}
+	doneCh          chan struct{}
+	shutdownTimeout time.Duration
+	closed          bool
+	closeOnce       sync.Once
+}
+
+func newServiceInfoDiskCacheRefresher(flushInterval time.Duration, writer diskCacheWriter) *serviceInfoDiskCacheRefresher {
+	refresher := &serviceInfoDiskCacheRefresher{
+		pendingEvents:   make(map[string]*serviceInfoDiskCacheRefreshEvent),
+		writer:          writer,
+		ticker:          time.NewTicker(flushInterval),
+		stopCh:          make(chan struct{}),
+		doneCh:          make(chan struct{}),
+		shutdownTimeout: defaultDiskCacheShutdownTimeout,
+	}
+	go refresher.run()
+	return refresher
+}
+
+func (r *serviceInfoDiskCacheRefresher) publish(event *serviceInfoDiskCacheRefreshEvent) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	if r.closed {
+		return
+	}
+	r.pendingEvents[event.cacheKey] = event
+}
+
+func (r *serviceInfoDiskCacheRefresher) pendingEventSize() int {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	return len(r.pendingEvents)
+}
+
+func (r *serviceInfoDiskCacheRefresher) close() {
+	r.closeOnce.Do(func() {
+		r.mux.Lock()
+		r.closed = true
+		r.mux.Unlock()
+		close(r.stopCh)
+		select {
+		case <-r.doneCh:
+		case <-time.After(r.shutdownTimeout):
+			logger.Warnf("timeout while waiting service info disk cache refresher to close, pending event size:%d", r.pendingEventSize())
+		}
+	})
+}
+
+func (r *serviceInfoDiskCacheRefresher) run() {
+	defer close(r.doneCh)
+	defer r.ticker.Stop()
+	for {
+		select {
+		case <-r.ticker.C:
+			r.safeFlushPendingEvents()
+		case <-r.stopCh:
+			r.safeFlushPendingEvents()
+			return
+		}
+	}
+}
+
+func (r *serviceInfoDiskCacheRefresher) safeFlushPendingEvents() {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Errorf("failed to flush service info disk cache refresh event, err:%v", err)
+		}
+	}()
+	r.flushPendingEvents()
+}
+
+func (r *serviceInfoDiskCacheRefresher) flushPendingEvents() {
+	r.mux.Lock()
+	events := make([]*serviceInfoDiskCacheRefreshEvent, 0, len(r.pendingEvents))
+	for _, event := range r.pendingEvents {
+		events = append(events, event)
+	}
+	r.mux.Unlock()
+
+	for _, event := range events {
+		if r.writer(event.service, event.cacheKey, event.cacheDir) {
+			r.mux.Lock()
+			if r.pendingEvents[event.cacheKey] == event {
+				delete(r.pendingEvents, event.cacheKey)
+			}
+			r.mux.Unlock()
+		}
+	}
+}

--- a/clients/naming_client/naming_cache/service_info_holder.go
+++ b/clients/naming_client/naming_cache/service_info_holder.go
@@ -38,6 +38,7 @@ type ServiceInfoHolder struct {
 	notLoadCacheAtStart  bool
 	subCallback          *SubscribeCallback
 	UpdateTimeMap        sync.Map
+	diskCacheRefresher   *serviceInfoDiskCacheRefresher
 }
 
 func NewServiceInfoHolder(namespace, cacheDir string, updateCacheWhenEmpty, notLoadCacheAtStart bool) *ServiceInfoHolder {
@@ -49,6 +50,7 @@ func NewServiceInfoHolder(namespace, cacheDir string, updateCacheWhenEmpty, notL
 		subCallback:          NewSubscribeCallback(),
 		UpdateTimeMap:        sync.Map{},
 		ServiceInfoMap:       sync.Map{},
+		diskCacheRefresher:   newServiceInfoDiskCacheRefresher(defaultDiskCacheFlushInterval, cache.WriteServicesToFileWithResult),
 	}
 
 	if !notLoadCacheAtStart {
@@ -94,7 +96,7 @@ func (s *ServiceInfoHolder) ProcessService(service *model.Service) {
 	s.ServiceInfoMap.Store(cacheKey, *service)
 	if !ok || checkInstanceChanged(oldDomain, *service) {
 		logger.Infof("service key:%s was updated to:%s", cacheKey, util.ToJsonString(service))
-		cache.WriteServicesToFile(service, cacheKey, s.cacheDir)
+		s.refreshDiskCache(service, cacheKey)
 		s.subCallback.ServiceChanged(cacheKey, service)
 	}
 	var count int
@@ -130,6 +132,43 @@ func (s *ServiceInfoHolder) StopUpdateIfContain(serviceName, clusters string) {
 
 func (s *ServiceInfoHolder) IsSubscribed(serviceName, clusters string) bool {
 	return s.subCallback.IsSubscribed(serviceName, clusters)
+}
+
+func (s *ServiceInfoHolder) Close() {
+	if s.diskCacheRefresher != nil {
+		s.diskCacheRefresher.close()
+	}
+}
+
+func (s *ServiceInfoHolder) refreshDiskCache(service *model.Service, cacheKey string) {
+	if s.diskCacheRefresher == nil {
+		return
+	}
+	s.diskCacheRefresher.publish(&serviceInfoDiskCacheRefreshEvent{
+		service:  cloneService(service),
+		cacheKey: cacheKey,
+		cacheDir: s.cacheDir,
+	})
+}
+
+func cloneService(service *model.Service) *model.Service {
+	if service == nil {
+		return nil
+	}
+	cloned := *service
+	if service.Hosts != nil {
+		cloned.Hosts = make([]model.Instance, len(service.Hosts))
+		for i, instance := range service.Hosts {
+			cloned.Hosts[i] = instance
+			if instance.Metadata != nil {
+				cloned.Hosts[i].Metadata = make(map[string]string, len(instance.Metadata))
+				for key, value := range instance.Metadata {
+					cloned.Hosts[i].Metadata[key] = value
+				}
+			}
+		}
+	}
+	return &cloned
 }
 
 func checkInstanceChanged(oldDomain interface{}, service model.Service) bool {

--- a/clients/naming_client/naming_cache/service_info_holder_test.go
+++ b/clients/naming_client/naming_cache/service_info_holder_test.go
@@ -18,11 +18,13 @@ package naming_cache
 import (
 	"fmt"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
 	"github.com/nacos-group/nacos-sdk-go/v2/model"
+	"github.com/nacos-group/nacos-sdk-go/v2/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,6 +143,124 @@ func TestHostReactor_isServiceInstanceChangedWithUnOrdered(t *testing.T) {
 	assert.True(t, changed)
 }
 
+func TestServiceInfoDiskCacheRefresherKeepsLatestSnapshot(t *testing.T) {
+	writeCount := 0
+	writtenServices := map[string]*model.Service{}
+	refresher := newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		writeCount++
+		writtenServices[cacheKey] = service
+		return true
+	})
+	defer refresher.close()
+
+	cacheKey := "DEFAULT_GROUP@@svc"
+	first := newTestService("svc", "1.1.1.1", 1)
+	second := newTestService("svc", "1.1.1.2", 2)
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{service: first, cacheKey: cacheKey, cacheDir: "cache"})
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{service: second, cacheKey: cacheKey, cacheDir: "cache"})
+
+	refresher.flushPendingEvents()
+
+	assert.Equal(t, 1, writeCount)
+	assert.Equal(t, "1.1.1.2", writtenServices[cacheKey].Hosts[0].Ip)
+	assert.Equal(t, 0, refresher.pendingEventSize())
+}
+
+func TestServiceInfoDiskCacheRefresherRetriesFailedWrite(t *testing.T) {
+	attempts := 0
+	refresher := newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		attempts++
+		return attempts > 1
+	})
+	defer refresher.close()
+
+	cacheKey := "DEFAULT_GROUP@@svc"
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{service: newTestService("svc", "1.1.1.1", 1), cacheKey: cacheKey, cacheDir: "cache"})
+
+	refresher.flushPendingEvents()
+
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, 1, refresher.pendingEventSize())
+
+	refresher.flushPendingEvents()
+
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, 0, refresher.pendingEventSize())
+}
+
+func TestServiceInfoDiskCacheRefresherCloseTimeout(t *testing.T) {
+	writerStarted := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	refresher := newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		close(writerStarted)
+		<-releaseWriter
+		return true
+	})
+	refresher.shutdownTimeout = 10 * time.Millisecond
+	refresher.publish(&serviceInfoDiskCacheRefreshEvent{
+		service:  newTestService("svc", "1.1.1.1", 1),
+		cacheKey: "DEFAULT_GROUP@@svc",
+		cacheDir: "cache",
+	})
+
+	closeReturned := make(chan struct{})
+	go func() {
+		refresher.close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-writerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("writer was not started")
+	}
+	select {
+	case <-closeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("close did not return after shutdown timeout")
+	}
+
+	close(releaseWriter)
+	select {
+	case <-refresher.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("refresher did not stop after writer was released")
+	}
+}
+
+func TestServiceInfoHolderProcessServiceQueuesDiskCacheBeforeCallback(t *testing.T) {
+	var writeCount int32
+	writtenIp := ""
+	holder := NewServiceInfoHolder("public", t.TempDir(), true, true)
+	holder.diskCacheRefresher.close()
+	holder.diskCacheRefresher = newServiceInfoDiskCacheRefresher(time.Hour, func(service *model.Service, cacheKey, cacheDir string) bool {
+		atomic.AddInt32(&writeCount, 1)
+		writtenIp = service.Hosts[0].Ip
+		return true
+	})
+
+	service := newTestService("svc", "1.1.1.1", 1)
+	callbackCalled := false
+	callback := func(services []model.Instance, err error) {
+		callbackCalled = true
+		assert.Equal(t, int32(0), atomic.LoadInt32(&writeCount))
+		services[0].Ip = "callback-mutated"
+	}
+	callbackWrapper := NewSubscribeCallbackFuncWrapper(NewClusterSelector(nil), &callback)
+	holder.RegisterCallback(util.GetGroupName(service.Name, service.GroupName), "", callbackWrapper)
+
+	holder.ProcessService(service)
+
+	assert.True(t, callbackCalled)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&writeCount))
+	assert.Equal(t, 1, holder.diskCacheRefresher.pendingEventSize())
+
+	holder.Close()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&writeCount))
+	assert.Equal(t, "1.1.1.1", writtenIp)
+}
+
 // create random ip addr
 func createRandomIp() string {
 	ip := fmt.Sprintf("%d.%d.%d.%d", rand.Intn(255), rand.Intn(255), rand.Intn(255), rand.Intn(255))
@@ -149,4 +269,19 @@ func createRandomIp() string {
 
 func creatRandomPort() uint64 {
 	return rand.Uint64()
+}
+
+func newTestService(serviceName, ip string, lastRefTime uint64) *model.Service {
+	return &model.Service{
+		Name:        serviceName,
+		GroupName:   "DEFAULT_GROUP",
+		LastRefTime: lastRefTime,
+		Hosts: []model.Instance{
+			{
+				Ip:       ip,
+				Port:     8848,
+				Metadata: map[string]string{"k": "v"},
+			},
+		},
+	}
 }

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -157,6 +157,9 @@ func (sc *NamingClient) BatchRegisterInstance(param vo.BatchRegisterInstancePara
 
 // DeregisterInstance ...
 func (sc *NamingClient) DeregisterInstance(param vo.DeregisterInstanceParam) (bool, error) {
+	if param.ServiceName == "" {
+		return false, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -197,6 +200,9 @@ func (sc *NamingClient) UpdateInstance(param vo.UpdateInstanceParam) (bool, erro
 
 // GetService Get service info by Group and DataId, clusters was optional
 func (sc *NamingClient) GetService(param vo.GetServiceParam) (service model.Service, err error) {
+	if param.ServiceName == "" {
+		return model.Service{}, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -231,6 +237,9 @@ func (sc *NamingClient) GetAllServicesInfo(param vo.GetAllServiceInfoParam) (mod
 
 // SelectAllInstances Get all instance by DataId 和 Group
 func (sc *NamingClient) SelectAllInstances(param vo.SelectAllInstancesParam) ([]model.Instance, error) {
+	if param.ServiceName == "" {
+		return nil, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -256,6 +265,9 @@ func (sc *NamingClient) SelectAllInstances(param vo.SelectAllInstancesParam) ([]
 
 // SelectInstances Get all instance by DataId, Group and Health
 func (sc *NamingClient) SelectInstances(param vo.SelectInstancesParam) ([]model.Instance, error) {
+	if param.ServiceName == "" {
+		return nil, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -293,6 +305,9 @@ func (sc *NamingClient) selectInstances(service model.Service, healthy bool) ([]
 
 // SelectOneHealthyInstance Get one healthy instance by DataId and Group
 func (sc *NamingClient) SelectOneHealthyInstance(param vo.SelectOneHealthInstanceParam) (*model.Instance, error) {
+	if param.ServiceName == "" {
+		return nil, errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -339,6 +354,9 @@ func (sc *NamingClient) selectOneHealthyInstances(service model.Service) (*model
 
 // Subscribe ...
 func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
+	if param.ServiceName == "" {
+		return errors.New("serviceName cannot be empty!")
+	}
 	if len(param.GroupName) == 0 {
 		param.GroupName = constant.DEFAULT_GROUP
 	}
@@ -351,6 +369,9 @@ func (sc *NamingClient) Subscribe(param *vo.SubscribeParam) error {
 
 // Unsubscribe ...
 func (sc *NamingClient) Unsubscribe(param *vo.SubscribeParam) (err error) {
+	if param.ServiceName == "" {
+		return errors.New("serviceName cannot be empty!")
+	}
 	clusterSelector := naming_cache.NewClusterSelector(param.Clusters)
 	callbackWrapper := naming_cache.NewSubscribeCallbackFuncWrapper(clusterSelector, &param.SubscribeCallback)
 	serviceFullName := util.GetGroupName(param.ServiceName, param.GroupName)

--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -87,11 +87,14 @@ func NewNamingClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 
 	naming.serviceProxy, err = NewNamingProxyDelegateWithRamCredentialProvider(ctx, clientConfig, serverConfig, httpAgent, naming.serviceInfoHolder, provider)
 
+	if err != nil {
+		cancel()
+		naming.serviceInfoHolder.Close()
+		return naming, err
+	}
+
 	if clientConfig.AsyncUpdateService {
 		go NewServiceInfoUpdater(ctx, naming.serviceInfoHolder, clientConfig.UpdateThreadNum, naming.serviceProxy).asyncUpdateService()
-	}
-	if err != nil {
-		return naming, err
 	}
 
 	return naming, nil
@@ -397,6 +400,9 @@ func (sc *NamingClient) CloseClient() {
 		return
 	}
 	sc.serviceProxy.CloseClient()
+	if sc.serviceInfoHolder != nil {
+		sc.serviceInfoHolder.Close()
+	}
 	sc.cancel()
 	sc.isClosed = true
 }

--- a/clients/naming_client/naming_client_test.go
+++ b/clients/naming_client/naming_client_test.go
@@ -457,6 +457,74 @@ func BenchmarkNamingClient_SelectOneHealthyInstances(b *testing.B) {
 
 }
 
+func TestNamingClient_Subscribe_EmptyServiceName(t *testing.T) {
+	callback := func(services []model.Instance, err error) {}
+	err := NewTestNamingClient().Subscribe(&vo.SubscribeParam{
+		ServiceName:       "",
+		GroupName:         "DEFAULT_GROUP",
+		SubscribeCallback: callback,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_Unsubscribe_EmptyServiceName(t *testing.T) {
+	callback := func(services []model.Instance, err error) {}
+	err := NewTestNamingClient().Unsubscribe(&vo.SubscribeParam{
+		ServiceName:       "",
+		GroupName:         "DEFAULT_GROUP",
+		SubscribeCallback: callback,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_DeregisterInstance_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().DeregisterInstance(vo.DeregisterInstanceParam{
+		ServiceName: "",
+		Ip:          "10.0.0.10",
+		Port:        80,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_GetService_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().GetService(vo.GetServiceParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_SelectAllInstances_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().SelectAllInstances(vo.SelectAllInstancesParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_SelectInstances_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().SelectInstances(vo.SelectInstancesParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
+func TestNamingClient_SelectOneHealthyInstance_EmptyServiceName(t *testing.T) {
+	_, err := NewTestNamingClient().SelectOneHealthyInstance(vo.SelectOneHealthInstanceParam{
+		ServiceName: "",
+		GroupName:   "DEFAULT_GROUP",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "serviceName cannot be empty")
+}
+
 func TestNamingClient_Unsubscribe_WithCallback_ShouldNotCallServiceProxyUnsubscribe(t *testing.T) {
 	// 创建一个带有回调函数的订阅参数
 	callback := func(services []model.Instance, err error) {

--- a/common/constant/client_config_options.go
+++ b/common/constant/client_config_options.go
@@ -244,3 +244,11 @@ func WithAppConnLabels(appConnLabels map[string]string) ClientOption {
 		config.AppConnLabels = appConnLabels
 	}
 }
+
+// WithClientIP sets custom client IP for gRPC communication.
+// This is useful in containerized environments where the auto-detected IP might be incorrect.
+func WithClientIP(clientIP string) ClientOption {
+	return func(config *ClientConfig) {
+		config.ClientIP = clientIP
+	}
+}

--- a/common/constant/config.go
+++ b/common/constant/config.go
@@ -61,6 +61,7 @@ type ClientConfig struct {
 	EndpointQueryParams  string                   // the address server  endpoint query params
 	ClusterName          string                   // the address server  clusterName
 	AppConnLabels        map[string]string        // app conn labels
+	ClientIP             string                   // the custom client ip, if not set, will use local ip auto detected
 }
 
 type ClientLogSamplingConfig struct {

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -31,8 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"google.golang.org/grpc/credentials"
-
 	"github.com/pkg/errors"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_request"

--- a/common/remote/rpc/grpc_client.go
+++ b/common/remote/rpc/grpc_client.go
@@ -31,6 +31,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/grpc/credentials"
+
 	"github.com/pkg/errors"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_request"
@@ -221,7 +223,7 @@ func (c *GrpcClient) createNewConnection(serverInfo ServerInfo) (*grpc.ClientCon
 }
 
 func (c *GrpcClient) getEnvTLSConfig(config *constant.TLSConfig) {
-	logger.Infof("check tls config ", config)
+	logger.Infof("check tls config: %v", config)
 
 	if config.Appointed == true {
 		return

--- a/common/remote/rpc/rpc_client.go
+++ b/common/remote/rpc/rpc_client.go
@@ -100,7 +100,7 @@ type RpcClient struct {
 	ctx                         context.Context
 	name                        string
 	labels                      map[string]string
-	currentConnection           IConnection
+	currentConnection           atomic.Value // stores IConnection
 	rpcClientStatus             RpcClientStatus
 	eventChan                   chan ConnectionEvent
 	reconnectionChan            chan ReconnectContext
@@ -112,6 +112,21 @@ type RpcClient struct {
 	mux                         *sync.Mutex
 	clientAbilities             rpc_request.ClientAbilities
 	Tenant                      string
+}
+
+// GetCurrentConnection returns the current connection, or nil if not set.
+func (r *RpcClient) GetCurrentConnection() IConnection {
+	v := r.currentConnection.Load()
+	if v == nil {
+		return nil
+	}
+	conn, _ := v.(IConnection)
+	return conn
+}
+
+// SetCurrentConnection atomically stores the current connection.
+func (r *RpcClient) SetCurrentConnection(conn IConnection) {
+	r.currentConnection.Store(conn)
 }
 
 type ServerRequestHandlerMapping struct {
@@ -336,7 +351,7 @@ func (r *RpcClient) Start() {
 	if currentConnection != nil {
 		logger.Infof("%s success to connect to server %+v on start up, connectionId=%s", r.name,
 			currentConnection.getServerInfo(), currentConnection.getConnectionId())
-		r.currentConnection = currentConnection
+		r.SetCurrentConnection(currentConnection)
 		atomic.StoreInt32((*int32)(&r.rpcClientStatus), (int32)(RUNNING))
 		r.notifyConnectionChange(CONNECTED)
 	} else {
@@ -349,11 +364,12 @@ func (r *RpcClient) notifyConnectionChange(eventType ConnectionStatus) {
 }
 
 func (r *RpcClient) notifyServerSrvChange() {
-	if r.currentConnection == nil {
+	conn := r.GetCurrentConnection()
+	if conn == nil {
 		r.switchServerAsync(ServerInfo{}, false)
 		return
 	}
-	curServerInfo := r.currentConnection.getServerInfo()
+	curServerInfo := conn.getServerInfo()
 	var found bool
 	for _, ele := range r.nacosServer.GetServerList() {
 		if ele.IpAddr == curServerInfo.serverIp {
@@ -420,7 +436,7 @@ func (r *RpcClient) switchServerAsync(recommendServerInfo ServerInfo, onRequestF
 
 func (r *RpcClient) reconnect(serverInfo ServerInfo, onRequestFail bool) {
 	if onRequestFail && r.sendHealthCheck() {
-		logger.Infof("%s server check success, currentServer is %+v", r.name, r.currentConnection.getServerInfo())
+		logger.Infof("%s server check success, currentServer is %+v", r.name, r.GetCurrentConnection().getServerInfo())
 		atomic.StoreInt32((*int32)(&r.rpcClientStatus), (int32)(RUNNING))
 		r.notifyConnectionChange(CONNECTED)
 		return
@@ -448,13 +464,13 @@ func (r *RpcClient) reconnect(serverInfo ServerInfo, onRequestFail bool) {
 			logger.Infof("%s success to connect a server %+v, connectionId=%s", r.name, serverInfo,
 				connectionNew.getConnectionId())
 
-			if r.currentConnection != nil {
+			if oldConn := r.GetCurrentConnection(); oldConn != nil {
 				logger.Infof("%s abandon prev connection, server is %+v, connectionId is %s", r.name, serverInfo,
-					r.currentConnection.getConnectionId())
-				r.currentConnection.setAbandon(true)
+					oldConn.getConnectionId())
+				oldConn.setAbandon(true)
 				r.closeConnection()
 			}
-			r.currentConnection = connectionNew
+			r.SetCurrentConnection(connectionNew)
 			atomic.StoreInt32((*int32)(&r.rpcClientStatus), (int32)(RUNNING))
 			r.notifyConnectionChange(CONNECTED)
 			return
@@ -480,8 +496,8 @@ func (r *RpcClient) reconnect(serverInfo ServerInfo, onRequestFail bool) {
 }
 
 func (r *RpcClient) closeConnection() {
-	if r.currentConnection != nil {
-		r.currentConnection.close()
+	if conn := r.GetCurrentConnection(); conn != nil {
+		conn.close()
 		r.notifyConnectionChange(DISCONNECTED)
 	}
 }
@@ -492,7 +508,7 @@ func (r *RpcClient) notifyConnectionEvent(event ConnectionEvent) {
 	if len(listeners) == 0 {
 		return
 	}
-	logger.Infof("%s notify %s event to listeners , connectionId=%s", r.name, event.toString(), r.currentConnection.getConnectionId())
+	logger.Infof("%s notify %s event to listeners , connectionId=%s", r.name, event.toString(), r.GetCurrentConnection().getConnectionId())
 	for _, v := range listeners {
 		if event.isConnected() {
 			v.OnConnected()
@@ -514,10 +530,11 @@ func (r *RpcClient) healthCheck(timer *time.Timer) {
 		r.lastActiveTimestamp.Store(time.Now())
 		return
 	} else {
-		if r.currentConnection == nil || r.isShutdown() {
+		conn := r.GetCurrentConnection()
+		if conn == nil || r.isShutdown() {
 			return
 		}
-		logger.Infof("%s server healthy check fail, currentConnection=%s", r.name, r.currentConnection.getConnectionId())
+		logger.Infof("%s server healthy check fail, currentConnection=%s", r.name, conn.getConnectionId())
 		atomic.StoreInt32((*int32)(&r.rpcClientStatus), (int32)(UNHEALTHY))
 		reconnectContext = ReconnectContext{onRequestFail: false}
 	}
@@ -525,10 +542,11 @@ func (r *RpcClient) healthCheck(timer *time.Timer) {
 }
 
 func (r *RpcClient) sendHealthCheck() bool {
-	if r.currentConnection == nil {
+	conn := r.GetCurrentConnection()
+	if conn == nil {
 		return false
 	}
-	response, err := r.currentConnection.request(rpc_request.NewHealthCheckRequest(),
+	response, err := conn.request(rpc_request.NewHealthCheckRequest(),
 		constant.DEFAULT_TIMEOUT_MILLS, r)
 	if err != nil {
 		logger.Errorf("client sendHealthCheck failed,err=%v", err)
@@ -595,12 +613,13 @@ func (r *RpcClient) Request(request rpc_request.IRequest, timeoutMills int64) (r
 	start := util.CurrentMillis()
 	var currentErr error
 	for retryTimes < constant.REQUEST_DOMAIN_RETRY_TIME && util.CurrentMillis() < start+timeoutMills {
-		if r.currentConnection == nil || !r.IsRunning() {
+		conn := r.GetCurrentConnection()
+		if conn == nil || !r.IsRunning() {
 			currentErr = waitReconnect(timeoutMills, &retryTimes, request,
 				errors.Errorf("client not connected, current status:%s", r.rpcClientStatus.getDesc()))
 			continue
 		}
-		response, err := r.currentConnection.request(request, timeoutMills, r)
+		response, err := conn.request(request, timeoutMills, r)
 		if err != nil {
 			currentErr = waitReconnect(timeoutMills, &retryTimes, request, err)
 			continue
@@ -610,7 +629,7 @@ func (r *RpcClient) Request(request rpc_request.IRequest, timeoutMills int64) (r
 				r.mux.Lock()
 				if atomic.CompareAndSwapInt32((*int32)(&r.rpcClientStatus), (int32)(RUNNING), (int32)(UNHEALTHY)) {
 					logger.Infof("Connection is unregistered, switch server, connectionId=%s, request=%s",
-						r.currentConnection.getConnectionId(), request.GetRequestType())
+						conn.getConnectionId(), request.GetRequestType())
 					r.switchServerAsync(ServerInfo{}, false)
 				}
 				r.mux.Unlock()

--- a/common/remote/rpc/rpc_client.go
+++ b/common/remote/rpc/rpc_client.go
@@ -169,7 +169,7 @@ func CreateClient(ctx context.Context, clientName string, connectionType Connect
 	cMux.Lock()
 	defer cMux.Unlock()
 	if _, ok := clientMap[clientName]; !ok {
-		logger.Infof("init rpc client for name ", clientName)
+		logger.Infof("init rpc client for name %s", clientName)
 		var rpcClient IRpcClient
 		if GRPC == connectionType {
 			rpcClient = NewGrpcClient(ctx, clientName, nacosServer, tlsConfig)

--- a/common/remote/rpc/rpc_client_connection_test.go
+++ b/common/remote/rpc/rpc_client_connection_test.go
@@ -1,0 +1,289 @@
+package rpc
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_request"
+	"github.com/nacos-group/nacos-sdk-go/v2/common/remote/rpc/rpc_response"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockConn implements IConnection for testing with an identifiable ID.
+type mockConn struct {
+	id         string
+	serverInfo ServerInfo
+	abandoned  bool
+	closed     bool
+}
+
+func (m *mockConn) request(request rpc_request.IRequest, timeoutMills int64, client *RpcClient) (rpc_response.IResponse, error) {
+	return nil, nil
+}
+func (m *mockConn) close()                    { m.closed = true }
+func (m *mockConn) getConnectionId() string   { return m.id }
+func (m *mockConn) getServerInfo() ServerInfo { return m.serverInfo }
+func (m *mockConn) setAbandon(flag bool)      { m.abandoned = flag }
+func (m *mockConn) getAbandon() bool          { return m.abandoned }
+
+// --- Unit Tests for GetCurrentConnection / SetCurrentConnection ---
+
+func TestGetCurrentConnection_InitiallyNil(t *testing.T) {
+	client := &RpcClient{}
+	conn := client.GetCurrentConnection()
+	assert.Nil(t, conn, "initial connection should be nil")
+}
+
+func TestSetAndGetCurrentConnection(t *testing.T) {
+	client := &RpcClient{}
+	mock := &mockConn{id: "conn-1", serverInfo: ServerInfo{serverIp: "10.0.0.1", serverPort: 8848}}
+
+	client.SetCurrentConnection(mock)
+	got := client.GetCurrentConnection()
+
+	assert.NotNil(t, got)
+	assert.Equal(t, "conn-1", got.getConnectionId())
+	assert.Equal(t, "10.0.0.1", got.getServerInfo().serverIp)
+}
+
+func TestSetCurrentConnection_Overwrite(t *testing.T) {
+	client := &RpcClient{}
+	conn1 := &mockConn{id: "conn-1"}
+	conn2 := &mockConn{id: "conn-2"}
+
+	client.SetCurrentConnection(conn1)
+	assert.Equal(t, "conn-1", client.GetCurrentConnection().getConnectionId())
+
+	client.SetCurrentConnection(conn2)
+	assert.Equal(t, "conn-2", client.GetCurrentConnection().getConnectionId())
+}
+
+// --- Concurrent Data Race Tests ---
+// These tests are specifically designed to trigger data races if the
+// atomic.Value protection is removed. Run with: go test -race -count=1
+
+func TestCurrentConnection_ConcurrentReadWrite(t *testing.T) {
+	// Simulates the exact race from #833: reconnect goroutine writes
+	// while healthCheck and Request goroutines read concurrently.
+	client := &RpcClient{}
+	client.SetCurrentConnection(&mockConn{id: "initial"})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: simulates reconnect() overwriting currentConnection
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				client.SetCurrentConnection(&mockConn{id: "conn-" + string(rune('A'+i%26))})
+			}
+		}
+	}()
+
+	// Reader 1: simulates healthCheck reading currentConnection
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				conn := client.GetCurrentConnection()
+				if conn != nil {
+					_ = conn.getConnectionId()
+					_ = conn.getServerInfo()
+				}
+			}
+		}
+	}()
+
+	// Reader 2: simulates Request() reading currentConnection
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				conn := client.GetCurrentConnection()
+				if conn != nil {
+					_ = conn.getConnectionId()
+				}
+			}
+		}
+	}()
+
+	// Reader 3: simulates NamingPushRequestHandler reading
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				conn := client.GetCurrentConnection()
+				if conn != nil {
+					_ = conn.getServerInfo()
+				}
+			}
+		}
+	}()
+
+	// Let them race for 200ms
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	// If we get here without -race reporting, the fix works.
+}
+
+func TestCurrentConnection_ConcurrentMultipleWriters(t *testing.T) {
+	// Stress test: multiple writers (shouldn't happen in production
+	// but verifies atomic.Value consistency even under stress)
+	client := &RpcClient{}
+	var wg sync.WaitGroup
+	const numWriters = 4
+	const numReaders = 8
+	const iterations = 1000
+
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				client.SetCurrentConnection(&mockConn{
+					id:         "writer-" + string(rune('0'+writerID)),
+					serverInfo: ServerInfo{serverIp: "192.168.1." + string(rune('0'+writerID))},
+				})
+			}
+		}(w)
+	}
+
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				conn := client.GetCurrentConnection()
+				if conn != nil {
+					id := conn.getConnectionId()
+					info := conn.getServerInfo()
+					// Verify consistency: id and serverInfo should come from the same connection
+					_ = id
+					_ = info
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	// Final state should be a valid connection
+	final := client.GetCurrentConnection()
+	assert.NotNil(t, final)
+}
+
+func TestCurrentConnection_ReadAfterReconnect(t *testing.T) {
+	// Simulates the real scenario: connection is set, then a reconnect
+	// replaces it, and concurrent readers never see a corrupted state.
+	client := &RpcClient{}
+	oldConn := &mockConn{id: "old-conn", serverInfo: ServerInfo{serverIp: "10.0.0.1", serverPort: 8848}}
+	newConn := &mockConn{id: "new-conn", serverInfo: ServerInfo{serverIp: "10.0.0.2", serverPort: 8848}}
+
+	client.SetCurrentConnection(oldConn)
+
+	var wg sync.WaitGroup
+	var readCount int64
+	stop := make(chan struct{})
+
+	// Readers that verify connection consistency
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					conn := client.GetCurrentConnection()
+					if conn != nil {
+						id := conn.getConnectionId()
+						ip := conn.getServerInfo().serverIp
+						// The id and ip must be from the SAME connection
+						if id == "old-conn" {
+							assert.Equal(t, "10.0.0.1", ip)
+						} else if id == "new-conn" {
+							assert.Equal(t, "10.0.0.2", ip)
+						}
+						atomic.AddInt64(&readCount, 1)
+					}
+				}
+			}
+		}()
+	}
+
+	// Give readers time to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Simulate reconnect: abandon old, set new
+	oldConn.abandoned = true
+	client.SetCurrentConnection(newConn)
+
+	// Let readers continue after reconnect
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	assert.True(t, atomic.LoadInt64(&readCount) > 0, "readers should have executed")
+	assert.Equal(t, "new-conn", client.GetCurrentConnection().getConnectionId())
+}
+
+func TestCurrentConnection_NilSafety(t *testing.T) {
+	// Verify GetCurrentConnection never panics, even before any Set
+	client := &RpcClient{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				conn := client.GetCurrentConnection()
+				// Should not panic; conn may be nil
+				_ = conn
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// --- Test closeConnection with atomic access ---
+
+func TestCloseConnection_WithActiveConnection(t *testing.T) {
+	client := &RpcClient{
+		eventChan: make(chan ConnectionEvent, 1),
+	}
+	mock := &mockConn{id: "to-close"}
+	client.SetCurrentConnection(mock)
+
+	client.closeConnection()
+
+	assert.True(t, mock.closed, "connection should be closed")
+}
+
+func TestCloseConnection_WithNilConnection(t *testing.T) {
+	client := &RpcClient{
+		eventChan: make(chan ConnectionEvent, 1),
+	}
+	// Should not panic when connection is nil
+	client.closeConnection()
+}

--- a/common/remote/rpc/server_request_handler.go
+++ b/common/remote/rpc/server_request_handler.go
@@ -91,7 +91,7 @@ func (c *NamingPushRequestHandler) RequestReply(request rpc_request.IRequest, cl
 	notifySubscriberRequest, ok := request.(*rpc_request.NotifySubscriberRequest)
 	if ok {
 		c.ServiceInfoHolder.ProcessService(&notifySubscriberRequest.ServiceInfo)
-		logger.Debugf("%s naming push response success ackId->%s", client.currentConnection.getConnectionId(),
+		logger.Debugf("%s naming push response success ackId->%s", client.GetCurrentConnection().getConnectionId(),
 			request.GetRequestId())
 		return &rpc_response.NotifySubscriberResponse{
 			Response: &rpc_response.Response{ResultCode: constant.RESPONSE_CODE_SUCCESS, Success: true},

--- a/common/remote/rpc/testdata/issue833_integration.go
+++ b/common/remote/rpc/testdata/issue833_integration.go
@@ -1,0 +1,172 @@
+// Integration test for #833 fix: data race on currentConnection.
+// Runs concurrent Subscribe/Unsubscribe/ServerHealthy operations against
+// a real Nacos server to verify no race under -race detector.
+//
+// Usage: NACOS_INTEGRATION_TEST=1 go run -race ./common/remote/rpc/testdata/issue833_integration_test.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/clients"
+	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
+	"github.com/nacos-group/nacos-sdk-go/v2/model"
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
+)
+
+func main() {
+	if os.Getenv("NACOS_INTEGRATION_TEST") != "1" {
+		fmt.Println("SKIP: set NACOS_INTEGRATION_TEST=1 to run")
+		os.Exit(0)
+	}
+
+	sc := []constant.ServerConfig{
+		*constant.NewServerConfig("127.0.0.1", 8848),
+	}
+	cc := *constant.NewClientConfig(
+		constant.WithNamespaceId(""),
+		constant.WithTimeoutMs(5000),
+		constant.WithNotLoadCacheAtStart(true),
+		constant.WithLogLevel("warn"),
+	)
+
+	namingClient, err := clients.NewNamingClient(vo.NacosClientParam{
+		ClientConfig:  &cc,
+		ServerConfigs: sc,
+	})
+	if err != nil {
+		fmt.Printf("FAIL: create naming client: %v\n", err)
+		os.Exit(1)
+	}
+
+	time.Sleep(2 * time.Second)
+	if !namingClient.ServerHealthy() {
+		fmt.Println("FAIL: client not healthy after startup")
+		os.Exit(1)
+	}
+	fmt.Println("=== Client connected and healthy ===")
+
+	// Test: 10 concurrent goroutines doing Subscribe/Unsubscribe for 5 seconds
+	// If there's a data race on currentConnection, -race will catch it
+	fmt.Println("=== Test 1: Concurrent Subscribe/Unsubscribe (5s, 10 goroutines) ===")
+	var wg sync.WaitGroup
+	var successCount, errorCount int64
+	done := make(chan struct{})
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			svcName := fmt.Sprintf("race-test-svc-%d", id)
+			callback := func(services []model.Instance, err error) {}
+
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					err := namingClient.Subscribe(&vo.SubscribeParam{
+						ServiceName:       svcName,
+						GroupName:         "DEFAULT_GROUP",
+						SubscribeCallback: callback,
+					})
+					if err == nil {
+						atomic.AddInt64(&successCount, 1)
+					} else {
+						atomic.AddInt64(&errorCount, 1)
+					}
+
+					_ = namingClient.ServerHealthy()
+
+					_ = namingClient.Unsubscribe(&vo.SubscribeParam{
+						ServiceName:       svcName,
+						GroupName:         "DEFAULT_GROUP",
+						SubscribeCallback: callback,
+					})
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+		}(i)
+	}
+
+	time.Sleep(5 * time.Second)
+	close(done)
+	wg.Wait()
+
+	fmt.Printf("  Results: success=%d, errors=%d\n", atomic.LoadInt64(&successCount), atomic.LoadInt64(&errorCount))
+	if atomic.LoadInt64(&successCount) == 0 {
+		fmt.Println("FAIL: zero successful operations")
+		os.Exit(1)
+	}
+	fmt.Println("  PASS: no data race detected by -race")
+
+	// Test 2: Verify client still healthy after stress
+	fmt.Println("\n=== Test 2: Client health after stress ===")
+	if !namingClient.ServerHealthy() {
+		fmt.Println("FAIL: client unhealthy after stress test")
+		os.Exit(1)
+	}
+	fmt.Println("  PASS: client still healthy")
+
+	// Test 3: Concurrent GetService + Subscribe (mixed read patterns)
+	fmt.Println("\n=== Test 3: Mixed concurrent operations (3s) ===")
+	done2 := make(chan struct{})
+	var ops int64
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			svcName := fmt.Sprintf("mixed-test-svc-%d", id)
+			callback := func(services []model.Instance, err error) {}
+			for {
+				select {
+				case <-done2:
+					return
+				default:
+					_ = namingClient.Subscribe(&vo.SubscribeParam{
+						ServiceName:       svcName,
+						GroupName:         "DEFAULT_GROUP",
+						SubscribeCallback: callback,
+					})
+					atomic.AddInt64(&ops, 1)
+					time.Sleep(2 * time.Millisecond)
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent SelectInstances (exercises Request -> currentConnection.request)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-done2:
+					return
+				default:
+					_, _ = namingClient.SelectAllInstances(vo.SelectAllInstancesParam{
+						ServiceName: fmt.Sprintf("select-test-svc-%d", id),
+						GroupName:   "DEFAULT_GROUP",
+					})
+					atomic.AddInt64(&ops, 1)
+					time.Sleep(2 * time.Millisecond)
+				}
+			}
+		}(i)
+	}
+
+	time.Sleep(3 * time.Second)
+	close(done2)
+	wg.Wait()
+
+	fmt.Printf("  Total ops: %d\n", atomic.LoadInt64(&ops))
+	fmt.Println("  PASS: no data race detected")
+
+	fmt.Println("\n=== ALL INTEGRATION TESTS PASSED ===")
+}

--- a/util/common.go
+++ b/util/common.go
@@ -67,8 +67,22 @@ func GetConfigCacheKey(dataId string, group string, tenant string) string {
 }
 
 var localIP = ""
+var customClientIP = ""
+
+// SetCustomClientIP sets a custom client IP to be used in gRPC communication.
+// This will override the auto-detected local IP.
+// Useful for containerized environments where the auto-detected IP might be incorrect.
+func SetCustomClientIP(ip string) {
+	customClientIP = ip
+	if len(customClientIP) > 0 {
+		logger.Infof("Custom Client IP set to: %s", customClientIP)
+	}
+}
 
 func LocalIP() string {
+	if customClientIP != "" {
+		return customClientIP
+	}
 	if localIP == "" {
 		netInterfaces, err := net.Interfaces()
 		if err != nil {

--- a/util/common.go
+++ b/util/common.go
@@ -21,7 +21,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
@@ -66,51 +69,92 @@ func GetConfigCacheKey(dataId string, group string, tenant string) string {
 	return dataId + constant.CONFIG_INFO_SPLITER + group + constant.CONFIG_INFO_SPLITER + tenant
 }
 
-var localIP = ""
-var customClientIP = ""
+// Environment variable key for overriding the client IP.
+// This takes highest priority, useful for containerized environments (e.g., K8s Pod spec).
+const EnvNacosClientLocalIP = "NACOS_CLIENT_LOCAL_IP"
 
-// SetCustomClientIP sets a custom client IP to be used in gRPC communication.
-// This will override the auto-detected local IP.
-// Useful for containerized environments where the auto-detected IP might be incorrect.
-func SetCustomClientIP(ip string) {
-	customClientIP = ip
-	if len(customClientIP) > 0 {
-		logger.Infof("Custom Client IP set to: %s", customClientIP)
-	}
+var (
+	resolvedIP   string
+	ipOnce       sync.Once
+	configuredIP atomic.Value // string; set via SetClientIPFromConfig before first LocalIP() call
+)
+
+// SetClientIPFromConfig stores the IP from ClientConfig.ClientIP.
+// Typically called by the client factory during initialization before any LocalIP() invocation.
+// This value has second priority after the NACOS_CLIENT_LOCAL_IP environment variable.
+// Uses atomic.Value so concurrent calls and concurrent LocalIP() reads are race-free.
+func SetClientIPFromConfig(ip string) {
+	configuredIP.Store(ip)
 }
 
-func LocalIP() string {
-	if customClientIP != "" {
-		return customClientIP
+func getConfiguredIP() string {
+	v := configuredIP.Load()
+	if v == nil {
+		return ""
 	}
-	if localIP == "" {
-		netInterfaces, err := net.Interfaces()
-		if err != nil {
-			logger.Errorf("get Interfaces failed,err:%+v", err)
-			return ""
-		}
+	s, _ := v.(string)
+	return s
+}
 
-		for i := 0; i < len(netInterfaces); i++ {
-			if ((netInterfaces[i].Flags & net.FlagUp) != 0) && ((netInterfaces[i].Flags & net.FlagLoopback) == 0) {
-				addrs, err := netInterfaces[i].Addrs()
-				if err != nil {
-					logger.Errorf("get InterfaceAddress failed,err:%+v", err)
-					return ""
-				}
-				for _, address := range addrs {
-					if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
-						localIP = ipnet.IP.String()
-						break
-					}
+// LocalIP returns the client IP address. Resolution happens exactly once with the following priority:
+//  1. NACOS_CLIENT_LOCAL_IP environment variable (highest, zero code change needed)
+//  2. ClientConfig.ClientIP set via WithClientIP option
+//  3. Auto-detected from network interfaces (first non-loopback IPv4)
+func LocalIP() string {
+	ipOnce.Do(func() {
+		// Priority 1: environment variable
+		if envIP := os.Getenv(EnvNacosClientLocalIP); envIP != "" {
+			resolvedIP = envIP
+			logger.Infof("Using client IP from environment variable %s: %s", EnvNacosClientLocalIP, resolvedIP)
+			return
+		}
+		// Priority 2: ClientConfig.ClientIP
+		if cfg := getConfiguredIP(); cfg != "" {
+			resolvedIP = cfg
+			logger.Infof("Using client IP from ClientConfig: %s", resolvedIP)
+			return
+		}
+		// Priority 3: auto-detect from network interfaces
+		resolvedIP = detectLocalIP()
+		if resolvedIP != "" {
+			logger.Infof("Local IP:%s", resolvedIP)
+		}
+	})
+	return resolvedIP
+}
+
+// detectLocalIP scans network interfaces and returns the first non-loopback IPv4 address.
+func detectLocalIP() string {
+	netInterfaces, err := net.Interfaces()
+	if err != nil {
+		logger.Errorf("get Interfaces failed,err:%+v", err)
+		return ""
+	}
+
+	for i := 0; i < len(netInterfaces); i++ {
+		if ((netInterfaces[i].Flags & net.FlagUp) != 0) && ((netInterfaces[i].Flags & net.FlagLoopback) == 0) {
+			addrs, err := netInterfaces[i].Addrs()
+			if err != nil {
+				logger.Errorf("get InterfaceAddress failed,err:%+v", err)
+				return ""
+			}
+			for _, address := range addrs {
+				if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
+					return ipnet.IP.String()
 				}
 			}
 		}
-
-		if len(localIP) > 0 {
-			logger.Infof("Local IP:%s", localIP)
-		}
 	}
-	return localIP
+	return ""
+}
+
+// resetLocalIPForTesting resets the IP resolution state. FOR TESTING ONLY.
+// Lowercase intentionally: this helper must NOT be part of the public API,
+// otherwise external callers could wipe an already-resolved IP at runtime.
+func resetLocalIPForTesting() {
+	resolvedIP = ""
+	configuredIP = atomic.Value{}
+	ipOnce = sync.Once{}
 }
 
 func GetDurationWithDefault(metadata map[string]string, key string, defaultDuration time.Duration) time.Duration {

--- a/util/local_ip_test.go
+++ b/util/local_ip_test.go
@@ -1,0 +1,294 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLocalIP_PriorityResolution covers all three priority levels of LocalIP() resolution.
+func TestLocalIP_PriorityResolution(t *testing.T) {
+	type setup struct {
+		envIP        string
+		configuredIP string
+	}
+	tests := []struct {
+		name           string
+		setup          setup
+		wantNonEmpty   bool   // true if we just want a non-empty result (auto-detect case)
+		wantExactValue string // empty means skip exact-value assertion
+		desc           string
+	}{
+		{
+			name:           "env_only",
+			setup:          setup{envIP: "10.0.1.100"},
+			wantExactValue: "10.0.1.100",
+			desc:           "env variable takes effect when set",
+		},
+		{
+			name:           "config_only",
+			setup:          setup{configuredIP: "10.0.2.200"},
+			wantExactValue: "10.0.2.200",
+			desc:           "ClientConfig.ClientIP takes effect when env empty",
+		},
+		{
+			name:           "env_overrides_config",
+			setup:          setup{envIP: "10.0.1.100", configuredIP: "10.0.2.200"},
+			wantExactValue: "10.0.1.100",
+			desc:           "env variable wins over ClientConfig.ClientIP",
+		},
+		{
+			name:         "auto_detect",
+			setup:        setup{},
+			wantNonEmpty: true,
+			desc:         "fallback to auto-detected IP when neither env nor config provided",
+		},
+		{
+			name:           "empty_env_falls_through",
+			setup:          setup{envIP: "", configuredIP: "10.0.3.30"},
+			wantExactValue: "10.0.3.30",
+			desc:           "empty env is treated as unset",
+		},
+		{
+			name:           "ipv6_env_value",
+			setup:          setup{envIP: "fe80::1"},
+			wantExactValue: "fe80::1",
+			desc:           "env value passed through as-is even for IPv6",
+		},
+		{
+			name:           "config_with_special_chars",
+			setup:          setup{configuredIP: "192.168.1.100"},
+			wantExactValue: "192.168.1.100",
+			desc:           "standard IPv4 from config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset state for each subtest (since LocalIP uses sync.Once)
+			resetLocalIPForTesting()
+
+			// Setup environment
+			if tt.setup.envIP != "" {
+				t.Setenv(EnvNacosClientLocalIP, tt.setup.envIP)
+			} else {
+				_ = os.Unsetenv(EnvNacosClientLocalIP)
+			}
+			if tt.setup.configuredIP != "" {
+				SetClientIPFromConfig(tt.setup.configuredIP)
+			}
+
+			got := LocalIP()
+
+			if tt.wantNonEmpty {
+				assert.NotEmpty(t, got, "expected auto-detected IP to be non-empty")
+			}
+			if tt.wantExactValue != "" {
+				assert.Equal(t, tt.wantExactValue, got, tt.desc)
+			}
+		})
+	}
+
+	resetLocalIPForTesting()
+}
+
+// TestLocalIP_OnceSemantics verifies that LocalIP() resolves exactly once
+// even if env/config change later.
+func TestLocalIP_OnceSemantics(t *testing.T) {
+	resetLocalIPForTesting()
+	defer resetLocalIPForTesting()
+
+	t.Setenv(EnvNacosClientLocalIP, "10.0.0.1")
+	first := LocalIP()
+	assert.Equal(t, "10.0.0.1", first)
+
+	// Change env after first resolution — should NOT affect subsequent calls
+	t.Setenv(EnvNacosClientLocalIP, "10.0.0.99")
+	SetClientIPFromConfig("10.0.0.50")
+
+	second := LocalIP()
+	assert.Equal(t, "10.0.0.1", second, "LocalIP() must return cached value on second call")
+}
+
+// TestSetClientIPFromConfig_BeforeFirstResolution verifies the typical client_factory flow.
+func TestSetClientIPFromConfig_BeforeFirstResolution(t *testing.T) {
+	resetLocalIPForTesting()
+	defer resetLocalIPForTesting()
+
+	_ = os.Unsetenv(EnvNacosClientLocalIP)
+	SetClientIPFromConfig("172.16.0.5")
+
+	got := LocalIP()
+	assert.Equal(t, "172.16.0.5", got)
+}
+
+// TestSetClientIPFromConfig_EmptyValueIgnored verifies passing empty string is a no-op.
+func TestSetClientIPFromConfig_EmptyValueIgnored(t *testing.T) {
+	resetLocalIPForTesting()
+	defer resetLocalIPForTesting()
+
+	_ = os.Unsetenv(EnvNacosClientLocalIP)
+	SetClientIPFromConfig("")
+
+	got := LocalIP()
+	// Empty config falls through to auto-detect; should not be empty in normal CI environments.
+	// We only assert that we don't return literal empty when the host has interfaces.
+	if got == "" {
+		t.Log("auto-detected IP is empty — likely no network interfaces; skipping strict assertion")
+	}
+}
+
+// TestLocalIP_ConcurrentAccess stresses the sync.Once guarantee under heavy concurrent load.
+// Without sync.Once, this would race on resolvedIP read/write.
+func TestLocalIP_ConcurrentAccess(t *testing.T) {
+	resetLocalIPForTesting()
+	defer resetLocalIPForTesting()
+
+	t.Setenv(EnvNacosClientLocalIP, "192.168.100.100")
+
+	const goroutines = 100
+	const iterations = 1000
+	var wg sync.WaitGroup
+	results := make(chan string, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var lastValue string
+			for j := 0; j < iterations; j++ {
+				lastValue = LocalIP()
+			}
+			results <- lastValue
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// All goroutines must observe the same value
+	expected := "192.168.100.100"
+	for v := range results {
+		assert.Equal(t, expected, v, "all concurrent reads must return the same resolved IP")
+	}
+}
+
+// TestLocalIP_ConcurrentSetAndRead verifies safety when SetClientIPFromConfig is called
+// concurrently with LocalIP() reads.
+// Note: in production, SetClientIPFromConfig is called once during init, before any reads.
+// But we still want this to be race-detector clean.
+func TestLocalIP_ConcurrentSetAndRead(t *testing.T) {
+	resetLocalIPForTesting()
+	defer resetLocalIPForTesting()
+
+	_ = os.Unsetenv(EnvNacosClientLocalIP)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+
+	// Half goroutines set, half read — race detector verifies no data race
+	for i := 0; i < goroutines/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			SetClientIPFromConfig("10.0.0.1")
+		}()
+	}
+	for i := 0; i < goroutines/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = LocalIP()
+		}()
+	}
+
+	wg.Wait()
+	// No assertion needed — purpose is to trigger race detector if there were one.
+}
+
+// TestEnvNacosClientLocalIP_ConstantValue ensures the constant matches the documented contract.
+// This is a regression guard: if anyone renames the constant, downstream users' env vars will break.
+func TestEnvNacosClientLocalIP_ConstantValue(t *testing.T) {
+	assert.Equal(t, "NACOS_CLIENT_LOCAL_IP", EnvNacosClientLocalIP,
+		"env variable name is part of the public contract; do not rename without a major version bump")
+}
+
+// TestLocalIP_AutoDetectFallback verifies fallback works when neither env nor config is set.
+func TestLocalIP_AutoDetectFallback(t *testing.T) {
+	resetLocalIPForTesting()
+	defer resetLocalIPForTesting()
+
+	_ = os.Unsetenv(EnvNacosClientLocalIP)
+	// Explicitly do not call SetClientIPFromConfig
+
+	got := LocalIP()
+	// Auto-detect should succeed in most environments
+	if got == "" {
+		t.Log("auto-detected IP is empty — host has no usable network interfaces")
+	} else {
+		// Should look like an IPv4 address
+		assert.Regexp(t, `^\d+\.\d+\.\d+\.\d+$`, got, "expected IPv4 dotted-decimal format")
+	}
+}
+
+// TestDetectLocalIP_NotEmpty exercises the internal helper directly.
+func TestDetectLocalIP_NotEmpty(t *testing.T) {
+	got := detectLocalIP()
+	if got == "" {
+		t.Log("detectLocalIP returned empty — host environment has no non-loopback IPv4 interfaces")
+	} else {
+		assert.Regexp(t, `^\d+\.\d+\.\d+\.\d+$`, got)
+	}
+}
+
+// TestLocalIP_PriorityOrder_Table compactly verifies the priority chain via table-driven cases.
+func TestLocalIP_PriorityOrder_Table(t *testing.T) {
+	tests := []struct {
+		name         string
+		envIP        string
+		configuredIP string
+		expected     string
+	}{
+		{"only_env", "1.1.1.1", "", "1.1.1.1"},
+		{"only_config", "", "2.2.2.2", "2.2.2.2"},
+		{"both_env_wins", "1.1.1.1", "2.2.2.2", "1.1.1.1"},
+		{"env_empty_string", "", "3.3.3.3", "3.3.3.3"},
+		{"config_empty_string", "4.4.4.4", "", "4.4.4.4"},
+		{"both_set_env_priority", "5.5.5.5", "6.6.6.6", "5.5.5.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetLocalIPForTesting()
+			if tt.envIP != "" {
+				t.Setenv(EnvNacosClientLocalIP, tt.envIP)
+			} else {
+				_ = os.Unsetenv(EnvNacosClientLocalIP)
+			}
+			SetClientIPFromConfig(tt.configuredIP)
+
+			got := LocalIP()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+
+	resetLocalIPForTesting()
+}


### PR DESCRIPTION
## Summary

Sync the 7 commits currently unique to `master` into `v3.x-dev`:

- validate `serviceName` to prevent the client UNHEALTHY cascade
- eliminate the `currentConnection` data race with `atomic.Value`
- support and align the configured ClientIP behavior
- improve gRPC TLS log formatting and remove the duplicate import
- refresh the naming disk cache asynchronously

## Conflict resolution

The merge had two import-block conflicts caused by the v3 module path migration. The new master-side logic and tests were preserved, while all newly introduced SDK imports were updated from `/v2` to `/v3`.

## Verification

- `GOTOOLCHAIN=go1.22.12 go test ./... -count=1`
- `GOTOOLCHAIN=local go test -race ./clients/... ./common/remote/rpc/... ./util/... -count=1`
- `gofmt` and `goimports` checks
- Nacos 2.5.2 integration tests: config publish/get/listen/delete and naming register/discover/deregister
- Nacos 3.2.0 integration tests: config publish/get/listen/delete and naming register/discover/deregister
