### PR TITLE
feat: expose auth login errors, TTL-based token refresh, and fix NacosAuthClient data races

### DIFF
--- a/clients/config_client/config_client.go
+++ b/clients/config_client/config_client.go
@@ -110,24 +110,29 @@ func NewConfigClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 	config.INacosClient = nc
 	clientConfig, err := nc.GetClientConfig()
 	if err != nil {
+		config.cancel()
 		return nil, err
 	}
 	serverConfig, err := nc.GetServerConfig()
 	if err != nil {
+		config.cancel()
 		return nil, err
 	}
 	httpAgent, err := nc.GetHttpAgent()
 	if err != nil {
+		config.cancel()
 		return nil, err
 	}
 
 	if err = initLogger(clientConfig); err != nil {
+		config.cancel()
 		return nil, err
 	}
 	clientConfig.CacheDir = clientConfig.CacheDir + string(os.PathSeparator) + "config"
 	config.configCacheDir = clientConfig.CacheDir
 
 	if config.configProxy, err = NewConfigProxyWithRamCredentialProvider(config.ctx, serverConfig, clientConfig, httpAgent, provider); err != nil {
+		config.cancel()
 		return nil, err
 	}
 
@@ -145,6 +150,7 @@ func NewConfigClientWithRamCredentialProvider(nc nacos_client.INacosClient, prov
 
 	uid, err := uuid.NewV4()
 	if err != nil {
+		config.cancel()
 		return nil, err
 	}
 

--- a/common/constant/client_config_options.go
+++ b/common/constant/client_config_options.go
@@ -252,3 +252,10 @@ func WithClientIP(clientIP string) ClientOption {
 		config.ClientIP = clientIP
 	}
 }
+
+// WithFailOnAuthError ...
+func WithFailOnAuthError(failOnAuthError bool) ClientOption {
+	return func(config *ClientConfig) {
+		config.FailOnAuthError = failOnAuthError
+	}
+}

--- a/common/constant/client_config_options_test.go
+++ b/common/constant/client_config_options_test.go
@@ -93,3 +93,9 @@ func TestNewClientConfigWithOptions(t *testing.T) {
 	assert.Equal(t, config.AccessKey, "accessKey_1")
 	assert.Equal(t, config.SecretKey, "secretKey_1")
 }
+
+func TestWithFailOnAuthError(t *testing.T) {
+	config := ClientConfig{}
+	WithFailOnAuthError(true)(&config)
+	assert.True(t, config.FailOnAuthError)
+}

--- a/common/constant/config.go
+++ b/common/constant/config.go
@@ -62,6 +62,7 @@ type ClientConfig struct {
 	ClusterName          string                   // the address server  clusterName
 	AppConnLabels        map[string]string        // app conn labels
 	ClientIP             string                   // the custom client ip, if not set, will use local ip auto detected
+	FailOnAuthError      bool                     // if true, NewClient returns an error when the initial credential login fails (HTTP 401/403); default false keeps backward-compatible behavior
 }
 
 type ClientLogSamplingConfig struct {

--- a/common/constant/config.go
+++ b/common/constant/config.go
@@ -62,7 +62,7 @@ type ClientConfig struct {
 	ClusterName          string                   // the address server  clusterName
 	AppConnLabels        map[string]string        // app conn labels
 	ClientIP             string                   // the custom client ip, if not set, will use local ip auto detected
-	FailOnAuthError      bool                     // if true, NewClient returns an error when the initial login gets any non-200 response from the auth endpoint (Nacos 2.x/3.x report rejected credentials with an inconsistent mix of 401/403/500); transport errors (server unreachable) stay retryable. Default false keeps backward-compatible behavior
+	FailOnAuthError      bool                     // if true, NewClient returns an error when the initial login gets any non-200 response from the auth endpoint (Nacos 2.x/3.x report rejected credentials with an inconsistent mix of 401/403/500) or a 200 response carrying no usable token; transport errors (server unreachable) stay retryable. Default false keeps backward-compatible behavior
 }
 
 type ClientLogSamplingConfig struct {

--- a/common/constant/config.go
+++ b/common/constant/config.go
@@ -62,7 +62,7 @@ type ClientConfig struct {
 	ClusterName          string                   // the address server  clusterName
 	AppConnLabels        map[string]string        // app conn labels
 	ClientIP             string                   // the custom client ip, if not set, will use local ip auto detected
-	FailOnAuthError      bool                     // if true, NewClient returns an error when the initial credential login fails (HTTP 401/403); default false keeps backward-compatible behavior
+	FailOnAuthError      bool                     // if true, NewClient returns an error when the initial login gets any non-200 response from the auth endpoint (Nacos 2.x/3.x report rejected credentials with an inconsistent mix of 401/403/500); transport errors (server unreachable) stay retryable. Default false keeps backward-compatible behavior
 }
 
 type ClientLogSamplingConfig struct {

--- a/common/nacos_server/nacos_server.go
+++ b/common/nacos_server/nacos_server.go
@@ -18,6 +18,7 @@ package nacos_server
 
 import (
 	"context"
+	stderrors "errors"
 	"io"
 	"math/rand"
 	"net/http"
@@ -91,7 +92,11 @@ func NewNacosServerWithRamCredentialProvider(ctx context.Context, serverList []c
 		ns.initRefreshSrvIfNeed(ctx)
 	}
 
-	ns.securityLogin.Login()
+	if err := ns.securityLogin.Login(); err != nil {
+		if clientCfg.FailOnAuthError && stderrors.Is(err, security.ErrLoginFailed) {
+			return nil, err
+		}
+	}
 	ns.securityLogin.AutoRefresh(ctx)
 	return &ns, nil
 }

--- a/common/nacos_server/nacos_server_test.go
+++ b/common/nacos_server/nacos_server_test.go
@@ -18,6 +18,12 @@ package nacos_server
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/common/http_agent"
@@ -184,4 +190,57 @@ func TestNacosServer_UpdateServerListForSecurityLogin(t *testing.T) {
 	client, ok := nacosAuthClient.(*security.NacosAuthClient)
 	assert.True(t, ok)
 	assert.Equal(t, server.GetServerList(), client.GetServerList())
+}
+
+// newUnauthorizedLoginServer starts an httptest server whose login endpoint
+// always returns 401, and returns a ServerConfig pointing at it.
+func newUnauthorizedLoginServer(t *testing.T) (*httptest.Server, constant.ServerConfig) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("unknown user!"))
+	}))
+	u, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(u.Host)
+	assert.NoError(t, err)
+	port, err := strconv.ParseUint(portStr, 10, 64)
+	assert.NoError(t, err)
+	return ts, constant.ServerConfig{Scheme: "http", IpAddr: host, Port: port, ContextPath: "/nacos"}
+}
+
+func TestNewNacosServer_FailOnAuthError_AbortsOnCredentialError(t *testing.T) {
+	ts, sc := newUnauthorizedLoginServer(t)
+	defer ts.Close()
+
+	clientConfig := constant.ClientConfig{
+		Username:        "wrong",
+		Password:        "wrong",
+		TimeoutMs:       3000,
+		FailOnAuthError: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // stop the AutoRefresh goroutine before the httptest server closes
+	_, err := NewNacosServer(ctx, []constant.ServerConfig{sc},
+		clientConfig, &http_agent.HttpAgent{}, 3000, "", nil)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, security.ErrLoginFailed))
+}
+
+func TestNewNacosServer_FailOnAuthError_Disabled_DoesNotAbort(t *testing.T) {
+	ts, sc := newUnauthorizedLoginServer(t)
+	defer ts.Close()
+
+	clientConfig := constant.ClientConfig{
+		Username:        "wrong",
+		Password:        "wrong",
+		TimeoutMs:       3000,
+		FailOnAuthError: false,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // stop the AutoRefresh goroutine before the httptest server closes
+	server, err := NewNacosServer(ctx, []constant.ServerConfig{sc},
+		clientConfig, &http_agent.HttpAgent{}, 3000, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, server)
 }

--- a/common/remote/rpc/rpc_client.go
+++ b/common/remote/rpc/rpc_client.go
@@ -616,7 +616,8 @@ func (r *RpcClient) Request(request rpc_request.IRequest, timeoutMills int64) (r
 		conn := r.GetCurrentConnection()
 		if conn == nil || !r.IsRunning() {
 			currentErr = waitReconnect(timeoutMills, &retryTimes, request,
-				errors.Errorf("client not connected, current status:%s", r.rpcClientStatus.getDesc()))
+				errors.Errorf("client not connected, current status:%s",
+					RpcClientStatus(atomic.LoadInt32((*int32)(&r.rpcClientStatus))).getDesc()))
 			continue
 		}
 		response, err := conn.request(request, timeoutMills, r)

--- a/common/security/errors.go
+++ b/common/security/errors.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// ErrLoginFailed marks a credential-level auth failure (HTTP 401/403), as
+// opposed to a transient network or server error. NewNacosServer only aborts
+// client construction on this error when ClientConfig.FailOnAuthError is set;
+// transient errors are always retried by the auto-refresh loop.
+var ErrLoginFailed = errors.New("nacos auth login failed")
+
+// classifyLoginStatus wraps a non-200 login response. HTTP 401/403 indicate a
+// credential problem and wrap ErrLoginFailed; any other status is treated as a
+// transient failure that should be retried rather than surfaced to NewClient.
+func classifyLoginStatus(statusCode int, body string) error {
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		return fmt.Errorf("%w: status=%d body=%s", ErrLoginFailed, statusCode, body)
+	}
+	return fmt.Errorf("nacos auth login unexpected response: status=%d body=%s", statusCode, body)
+}

--- a/common/security/errors.go
+++ b/common/security/errors.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 )
 
-// ErrLoginFailed marks an auth login failure: the login endpoint returned a
-// non-200 response, so no access token was issued. NewNacosServer aborts client
-// construction on this error only when ClientConfig.FailOnAuthError is set.
-// Transport errors (server unreachable) are not wrapped in this and stay
+// ErrLoginFailed marks an auth login failure: either the login endpoint
+// returned a non-200 response, or it returned 200 with a body that carries no
+// usable token (missing/empty/non-string accessToken, or missing/non-positive
+// tokenTtl) — in both cases no access token was issued. NewNacosServer aborts
+// client construction on this error only when ClientConfig.FailOnAuthError is
+// set. Transport errors (server unreachable) are not wrapped in this and stay
 // transient, always retried by the auto-refresh loop.
 var ErrLoginFailed = errors.New("nacos auth login failed")
 

--- a/common/security/errors.go
+++ b/common/security/errors.go
@@ -19,21 +19,23 @@ package security
 import (
 	"errors"
 	"fmt"
-	"net/http"
 )
 
-// ErrLoginFailed marks a credential-level auth failure (HTTP 401/403), as
-// opposed to a transient network or server error. NewNacosServer only aborts
-// client construction on this error when ClientConfig.FailOnAuthError is set;
-// transient errors are always retried by the auto-refresh loop.
+// ErrLoginFailed marks an auth login failure: the login endpoint returned a
+// non-200 response, so no access token was issued. NewNacosServer aborts client
+// construction on this error only when ClientConfig.FailOnAuthError is set.
+// Transport errors (server unreachable) are not wrapped in this and stay
+// transient, always retried by the auto-refresh loop.
 var ErrLoginFailed = errors.New("nacos auth login failed")
 
-// classifyLoginStatus wraps a non-200 login response. HTTP 401/403 indicate a
-// credential problem and wrap ErrLoginFailed; any other status is treated as a
-// transient failure that should be retried rather than surfaced to NewClient.
+// classifyLoginStatus wraps any non-200 login response as ErrLoginFailed. Real
+// Nacos servers return an inconsistent mix of 401/403/500 for rejected
+// credentials across versions (2.x returns 403 for a wrong password but 500 for
+// an unknown user; 3.x is the reverse), and a 5xx body carries no reliable
+// credential hint. Since any non-200 response means no token was issued, all are
+// surfaced as an auth failure so FailOnAuthError can act on them consistently.
+// Transport errors (server unreachable) never reach here — the caller keeps
+// those transient and retryable.
 func classifyLoginStatus(statusCode int, body string) error {
-	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
-		return fmt.Errorf("%w: status=%d body=%s", ErrLoginFailed, statusCode, body)
-	}
-	return fmt.Errorf("nacos auth login unexpected response: status=%d body=%s", statusCode, body)
+	return fmt.Errorf("%w: status=%d body=%s", ErrLoginFailed, statusCode, body)
 }

--- a/common/security/errors_test.go
+++ b/common/security/errors_test.go
@@ -24,16 +24,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClassifyLoginStatus_Credential(t *testing.T) {
-	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
-		err := classifyLoginStatus(code, "unknown user!")
+func TestClassifyLoginStatus_WrapsAllNon200(t *testing.T) {
+	// Real Nacos servers return an inconsistent mix of 401/403/500 for rejected
+	// credentials across versions (2.x: 403 for a wrong password, 500 for an
+	// unknown user; 3.x is the reverse), and a 5xx body carries no reliable
+	// credential hint. Any non-200 login response means no token was issued, so
+	// classifyLoginStatus wraps them all as ErrLoginFailed for FailOnAuthError
+	// to act on. Transport errors (server unreachable) never reach here.
+	for _, code := range []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusInternalServerError,
+		http.StatusBadRequest,
+	} {
+		err := classifyLoginStatus(code, "rejected")
 		assert.Error(t, err)
-		assert.True(t, errors.Is(err, ErrLoginFailed), "status %d should be credential error", code)
+		assert.True(t, errors.Is(err, ErrLoginFailed), "status %d should wrap ErrLoginFailed", code)
 	}
-}
-
-func TestClassifyLoginStatus_Transient(t *testing.T) {
-	err := classifyLoginStatus(http.StatusInternalServerError, "server busy")
-	assert.Error(t, err)
-	assert.False(t, errors.Is(err, ErrLoginFailed), "5xx should not be credential error")
 }

--- a/common/security/errors_test.go
+++ b/common/security/errors_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyLoginStatus_Credential(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		err := classifyLoginStatus(code, "unknown user!")
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrLoginFailed), "status %d should be credential error", code)
+	}
+}
+
+func TestClassifyLoginStatus_Transient(t *testing.T) {
+	err := classifyLoginStatus(http.StatusInternalServerError, "server busy")
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, ErrLoginFailed), "5xx should not be credential error")
+}

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/http_agent"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/logger"
-	"github.com/pkg/errors"
 )
 
 type NacosAuthClient struct {
@@ -161,8 +160,7 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 	}
 
 	if resp.StatusCode != constant.RESPONSE_CODE_SUCCESS {
-		errMsg := string(bytes)
-		return false, errors.New(errMsg)
+		return false, classifyLoginStatus(resp.StatusCode, string(bytes))
 	}
 
 	var result map[string]interface{}

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -3,6 +3,7 @@ package security
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -192,15 +193,21 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 		return false, err
 	}
 
-	if val, ok := result[constant.KEY_ACCESS_TOKEN]; ok {
-		ac.accessToken.Store(val)
-		ttlRaw, _ := result[constant.KEY_TOKEN_TTL].(float64)
-		ac.mux.Lock()
-		ac.lastRefreshTime = time.Now().Unix()
-		ac.tokenTtl = int64(ttlRaw)
-		ac.tokenRefreshWindow = ac.tokenTtl / 10
-		ac.mux.Unlock()
+	accessToken, ok := result[constant.KEY_ACCESS_TOKEN].(string)
+	if !ok || accessToken == "" {
+		return false, fmt.Errorf("%w: login response missing a valid accessToken: %s", ErrLoginFailed, string(bytes))
 	}
+	ttl, ok := result[constant.KEY_TOKEN_TTL].(float64)
+	if !ok || ttl <= 0 {
+		return false, fmt.Errorf("%w: login response has missing or non-positive tokenTtl: %s", ErrLoginFailed, string(bytes))
+	}
+
+	ac.accessToken.Store(accessToken)
+	ac.mux.Lock()
+	ac.lastRefreshTime = time.Now().Unix()
+	ac.tokenTtl = int64(ttl)
+	ac.tokenRefreshWindow = ac.tokenTtl / 10
+	ac.mux.Unlock()
 
 	return true, nil
 }

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -194,9 +194,10 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 
 	if val, ok := result[constant.KEY_ACCESS_TOKEN]; ok {
 		ac.accessToken.Store(val)
+		ttlRaw, _ := result[constant.KEY_TOKEN_TTL].(float64)
 		ac.mux.Lock()
 		ac.lastRefreshTime = time.Now().Unix()
-		ac.tokenTtl = int64(result[constant.KEY_TOKEN_TTL].(float64))
+		ac.tokenTtl = int64(ttlRaw)
 		ac.tokenRefreshWindow = ac.tokenTtl / 10
 		ac.mux.Unlock()
 	}

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -30,6 +30,44 @@ type NacosAuthClient struct {
 	mux                sync.Mutex
 }
 
+const (
+	// retryDelay is the cadence for retrying before the first successful login
+	// and for backing off after a failed refresh.
+	retryDelay = 5 * time.Second
+	// minRefreshDelay floors a scheduled refresh so a passed or near deadline
+	// cannot spin the timer into a tight login loop.
+	minRefreshDelay = 1 * time.Second
+)
+
+// refreshDeadlineUnix returns the unix second at which the token should be
+// refreshed — two windows before expiry — and whether a successful login has
+// established one yet. The guard in login() and the scheduler in AutoRefresh()
+// both derive from this single rule so they never diverge.
+func (ac *NacosAuthClient) refreshDeadlineUnix() (int64, bool) {
+	ac.mux.Lock()
+	defer ac.mux.Unlock()
+	if ac.lastRefreshTime <= 0 || ac.tokenTtl <= 0 {
+		return 0, false
+	}
+	return ac.lastRefreshTime + ac.tokenTtl - 2*ac.tokenRefreshWindow, true
+}
+
+// nextRefreshDelay returns how long to wait before the next refresh attempt,
+// derived from the refresh deadline and the current time. Before any successful
+// login it returns retryDelay; a passed or near deadline is clamped to
+// minRefreshDelay so the timer never tight-loops.
+func (ac *NacosAuthClient) nextRefreshDelay() time.Duration {
+	deadline, ok := ac.refreshDeadlineUnix()
+	if !ok {
+		return retryDelay
+	}
+	delay := time.Duration(deadline-time.Now().Unix()) * time.Second
+	if delay < minRefreshDelay {
+		delay = minRefreshDelay
+	}
+	return delay
+}
+
 func NewNacosAuthClient(clientCfg constant.ClientConfig, serverCfgs []constant.ServerConfig, agent http_agent.IHttpAgent) *NacosAuthClient {
 	client := &NacosAuthClient{
 		username:    clientCfg.Username,
@@ -67,33 +105,21 @@ func (ac *NacosAuthClient) AutoRefresh(ctx context.Context) {
 	}
 
 	go func() {
-		ac.mux.Lock()
-		lastRefreshTime := ac.lastRefreshTime
-		tokenTtl := ac.tokenTtl
-		tokenRefreshWindow := ac.tokenRefreshWindow
-		ac.mux.Unlock()
-
-		var timer *time.Timer
-		if lastLoginSuccess := lastRefreshTime > 0 && tokenTtl > 0 && tokenRefreshWindow > 0; lastLoginSuccess {
-			timer = time.NewTimer(time.Second * time.Duration(tokenTtl-tokenRefreshWindow))
-		} else {
-			timer = time.NewTimer(time.Second * time.Duration(5))
-		}
+		timer := time.NewTimer(ac.nextRefreshDelay())
 		defer timer.Stop()
 		for {
 			select {
 			case <-timer.C:
-				_, err := ac.Login()
-				if err != nil {
+				if _, err := ac.Login(); err != nil {
 					logger.Errorf("login has error %+v", err)
-					timer.Reset(time.Second * time.Duration(5))
+					timer.Reset(retryDelay)
 				} else {
 					ac.mux.Lock()
 					ttl := ac.tokenTtl
 					window := ac.tokenRefreshWindow
 					ac.mux.Unlock()
 					logger.Infof("login success, tokenTtl: %+v seconds, tokenRefreshWindow: %+v seconds", ttl, window)
-					timer.Reset(time.Second * time.Duration(ttl-window))
+					timer.Reset(ac.nextRefreshDelay())
 				}
 			case <-ctx.Done():
 				return
@@ -132,18 +158,10 @@ func (ac *NacosAuthClient) GetServerList() []constant.ServerConfig {
 }
 
 func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
-	ac.mux.Lock()
-	lastRefreshTime := ac.lastRefreshTime
-	tokenTtl := ac.tokenTtl
-	tokenRefreshWindow := ac.tokenRefreshWindow
-	ac.mux.Unlock()
-
-	if lastRefreshTime > 0 && tokenTtl > 0 {
-		// We refresh 2 windows before expiration to ensure continuous availability
-		tokenRefreshTime := lastRefreshTime + tokenTtl - 2*tokenRefreshWindow
-		if time.Now().Unix() < tokenRefreshTime {
-			return true, nil
-		}
+	// Skip the network round-trip while the token is still comfortably valid,
+	// using the same deadline rule the scheduler uses.
+	if deadline, ok := ac.refreshDeadlineUnix(); ok && time.Now().Unix() < deadline {
+		return true, nil
 	}
 	if ac.username == "" {
 		ac.mux.Lock()

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -3,6 +3,7 @@ package security
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -134,15 +135,25 @@ func (ac *NacosAuthClient) Login() (bool, error) {
 	copy(servers, ac.serverCfgs)
 	ac.mux.Unlock()
 
-	var throwable error = nil
+	// Keep any credential failure even when a later server only yields a
+	// transport error, so FailOnAuthError does not depend on server order.
+	var credentialErr, lastErr error
 	for i := 0; i < len(servers); i++ {
 		result, err := ac.login(servers[i])
-		throwable = err
 		if result {
 			return true, nil
 		}
+		if err != nil {
+			lastErr = err
+			if credentialErr == nil && errors.Is(err, ErrLoginFailed) {
+				credentialErr = err
+			}
+		}
 	}
-	return false, throwable
+	if credentialErr != nil {
+		return false, credentialErr
+	}
+	return false, lastErr
 }
 
 func (ac *NacosAuthClient) UpdateServerList(serverList []constant.ServerConfig) {
@@ -211,14 +222,19 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 		return false, err
 	}
 
+	// NOTE: never put the raw response body in these errors. They are logged by
+	// SecurityProxy.Login/AutoRefresh and returned to callers, and a 200 body can
+	// carry a usable access token — including it would leak the token into
+	// application logs. Report only non-sensitive details.
 	accessToken, ok := result[constant.KEY_ACCESS_TOKEN].(string)
 	if !ok || accessToken == "" {
-		return false, fmt.Errorf("%w: login response missing a valid accessToken: %s", ErrLoginFailed, string(bytes))
+		return false, fmt.Errorf("%w: login response has no usable accessToken", ErrLoginFailed)
 	}
 	ttlRaw, ok := result[constant.KEY_TOKEN_TTL].(float64)
 	ttlSeconds := int64(ttlRaw)
 	if !ok || ttlSeconds <= 0 {
-		return false, fmt.Errorf("%w: login response has missing or non-positive tokenTtl: %s", ErrLoginFailed, string(bytes))
+		return false, fmt.Errorf("%w: login response has missing or non-positive tokenTtl: %v",
+			ErrLoginFailed, result[constant.KEY_TOKEN_TTL])
 	}
 
 	ac.accessToken.Store(accessToken)

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -25,6 +26,7 @@ type NacosAuthClient struct {
 	agent              http_agent.IHttpAgent
 	clientCfg          constant.ClientConfig
 	serverCfgs         []constant.ServerConfig
+	mux                sync.Mutex
 }
 
 func NewNacosAuthClient(clientCfg constant.ClientConfig, serverCfgs []constant.ServerConfig, agent http_agent.IHttpAgent) *NacosAuthClient {
@@ -58,17 +60,21 @@ func (ac *NacosAuthClient) GetSecurityInfo(resource RequestResource) map[string]
 }
 
 func (ac *NacosAuthClient) AutoRefresh(ctx context.Context) {
-
 	// If the username is not set, the automatic refresh Token is not enabled
-
 	if ac.username == "" {
 		return
 	}
 
 	go func() {
+		ac.mux.Lock()
+		lastRefreshTime := ac.lastRefreshTime
+		tokenTtl := ac.tokenTtl
+		tokenRefreshWindow := ac.tokenRefreshWindow
+		ac.mux.Unlock()
+
 		var timer *time.Timer
-		if lastLoginSuccess := ac.lastRefreshTime > 0 && ac.tokenTtl > 0 && ac.tokenRefreshWindow > 0; lastLoginSuccess {
-			timer = time.NewTimer(time.Second * time.Duration(ac.tokenTtl-ac.tokenRefreshWindow))
+		if lastLoginSuccess := lastRefreshTime > 0 && tokenTtl > 0 && tokenRefreshWindow > 0; lastLoginSuccess {
+			timer = time.NewTimer(time.Second * time.Duration(tokenTtl-tokenRefreshWindow))
 		} else {
 			timer = time.NewTimer(time.Second * time.Duration(5))
 		}
@@ -81,8 +87,12 @@ func (ac *NacosAuthClient) AutoRefresh(ctx context.Context) {
 					logger.Errorf("login has error %+v", err)
 					timer.Reset(time.Second * time.Duration(5))
 				} else {
-					logger.Infof("login success, tokenTtl: %+v seconds, tokenRefreshWindow: %+v seconds", ac.tokenTtl, ac.tokenRefreshWindow)
-					timer.Reset(time.Second * time.Duration(ac.tokenTtl-ac.tokenRefreshWindow))
+					ac.mux.Lock()
+					ttl := ac.tokenTtl
+					window := ac.tokenRefreshWindow
+					ac.mux.Unlock()
+					logger.Infof("login success, tokenTtl: %+v seconds, tokenRefreshWindow: %+v seconds", ttl, window)
+					timer.Reset(time.Second * time.Duration(ttl-window))
 				}
 			case <-ctx.Done():
 				return
@@ -92,9 +102,14 @@ func (ac *NacosAuthClient) AutoRefresh(ctx context.Context) {
 }
 
 func (ac *NacosAuthClient) Login() (bool, error) {
+	ac.mux.Lock()
+	servers := make([]constant.ServerConfig, len(ac.serverCfgs))
+	copy(servers, ac.serverCfgs)
+	ac.mux.Unlock()
+
 	var throwable error = nil
-	for i := 0; i < len(ac.serverCfgs); i++ {
-		result, err := ac.login(ac.serverCfgs[i])
+	for i := 0; i < len(servers); i++ {
+		result, err := ac.login(servers[i])
 		throwable = err
 		if result {
 			return true, nil
@@ -104,36 +119,45 @@ func (ac *NacosAuthClient) Login() (bool, error) {
 }
 
 func (ac *NacosAuthClient) UpdateServerList(serverList []constant.ServerConfig) {
+	ac.mux.Lock()
 	ac.serverCfgs = serverList
+	ac.mux.Unlock()
 }
 
 func (ac *NacosAuthClient) GetServerList() []constant.ServerConfig {
+	ac.mux.Lock()
+	defer ac.mux.Unlock()
 	return ac.serverCfgs
 }
 
 func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
-	if ac.lastRefreshTime > 0 && ac.tokenTtl > 0 {
+	ac.mux.Lock()
+	lastRefreshTime := ac.lastRefreshTime
+	tokenTtl := ac.tokenTtl
+	tokenRefreshWindow := ac.tokenRefreshWindow
+	ac.mux.Unlock()
+
+	if lastRefreshTime > 0 && tokenTtl > 0 {
 		// We refresh 2 windows before expiration to ensure continuous availability
-		tokenRefreshTime := ac.lastRefreshTime + ac.tokenTtl - 2*ac.tokenRefreshWindow
+		tokenRefreshTime := lastRefreshTime + tokenTtl - 2*tokenRefreshWindow
 		if time.Now().Unix() < tokenRefreshTime {
 			return true, nil
 		}
 	}
 	if ac.username == "" {
+		ac.mux.Lock()
 		ac.lastRefreshTime = time.Now().Unix()
+		ac.mux.Unlock()
 		return true, nil
 	}
 
 	contextPath := server.ContextPath
-
 	if !strings.HasPrefix(contextPath, "/") {
 		contextPath = "/" + contextPath
 	}
-
 	if strings.HasSuffix(contextPath, "/") {
 		contextPath = contextPath[0 : len(contextPath)-1]
 	}
-
 	if server.Scheme == "" {
 		server.Scheme = "http"
 	}
@@ -147,7 +171,6 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 		"username": ac.username,
 		"password": ac.password,
 	})
-
 	if err != nil {
 		return false, err
 	}
@@ -164,20 +187,19 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 	}
 
 	var result map[string]interface{}
-
 	err = json.Unmarshal(bytes, &result)
-
 	if err != nil {
 		return false, err
 	}
 
 	if val, ok := result[constant.KEY_ACCESS_TOKEN]; ok {
 		ac.accessToken.Store(val)
+		ac.mux.Lock()
 		ac.lastRefreshTime = time.Now().Unix()
 		ac.tokenTtl = int64(result[constant.KEY_TOKEN_TTL].(float64))
 		ac.tokenRefreshWindow = ac.tokenTtl / 10
+		ac.mux.Unlock()
 	}
 
 	return true, nil
-
 }

--- a/common/security/nacos_auth_client.go
+++ b/common/security/nacos_auth_client.go
@@ -215,16 +215,22 @@ func (ac *NacosAuthClient) login(server constant.ServerConfig) (bool, error) {
 	if !ok || accessToken == "" {
 		return false, fmt.Errorf("%w: login response missing a valid accessToken: %s", ErrLoginFailed, string(bytes))
 	}
-	ttl, ok := result[constant.KEY_TOKEN_TTL].(float64)
-	if !ok || ttl <= 0 {
+	ttlRaw, ok := result[constant.KEY_TOKEN_TTL].(float64)
+	ttlSeconds := int64(ttlRaw)
+	if !ok || ttlSeconds <= 0 {
 		return false, fmt.Errorf("%w: login response has missing or non-positive tokenTtl: %s", ErrLoginFailed, string(bytes))
 	}
 
 	ac.accessToken.Store(accessToken)
 	ac.mux.Lock()
 	ac.lastRefreshTime = time.Now().Unix()
-	ac.tokenTtl = int64(ttl)
+	ac.tokenTtl = ttlSeconds
 	ac.tokenRefreshWindow = ac.tokenTtl / 10
+	if ac.tokenRefreshWindow < 1 {
+		// keep at least one second of margin so the refresh deadline never
+		// collapses onto the expiry instant for very short TTLs
+		ac.tokenRefreshWindow = 1
+	}
 	ac.mux.Unlock()
 
 	return true, nil

--- a/common/security/nacos_auth_client_test.go
+++ b/common/security/nacos_auth_client_test.go
@@ -408,3 +408,35 @@ func TestNacosAuthClient_Login_ValidResponseStillSucceeds(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "valid-token", client.GetAccessToken())
 }
+
+func TestNacosAuthClient_RefreshDeadline_Deterministic(t *testing.T) {
+	client := NewNacosAuthClient(constant.ClientConfig{Username: "u"}, nil, nil)
+	client.mux.Lock()
+	client.lastRefreshTime = 1_000_000
+	client.tokenTtl = 10
+	client.tokenRefreshWindow = 1
+	client.mux.Unlock()
+
+	deadline, ok := client.refreshDeadlineUnix()
+	assert.True(t, ok)
+	// lastRefreshTime + ttl - 2*window = 1000000 + 10 - 2 = 1000008
+	assert.Equal(t, int64(1_000_008), deadline, "deadline must be two windows before expiry")
+}
+
+func TestNacosAuthClient_RefreshDeadline_NotLoggedIn(t *testing.T) {
+	client := NewNacosAuthClient(constant.ClientConfig{Username: "u"}, nil, nil)
+	_, ok := client.refreshDeadlineUnix()
+	assert.False(t, ok, "no deadline before a successful login")
+	assert.Equal(t, retryDelay, client.nextRefreshDelay(), "unauthenticated delay is the retry cadence")
+}
+
+func TestNacosAuthClient_NextRefreshDelay_ClampsPastDeadline(t *testing.T) {
+	client := NewNacosAuthClient(constant.ClientConfig{Username: "u"}, nil, nil)
+	client.mux.Lock()
+	// deadline far in the past → raw delay is negative → must clamp to minRefreshDelay
+	client.lastRefreshTime = 1
+	client.tokenTtl = 10
+	client.tokenRefreshWindow = 1
+	client.mux.Unlock()
+	assert.Equal(t, minRefreshDelay, client.nextRefreshDelay(), "a passed deadline must not spin the timer")
+}

--- a/common/security/nacos_auth_client_test.go
+++ b/common/security/nacos_auth_client_test.go
@@ -349,3 +349,62 @@ func TestNacosAuthClient_ConcurrentLoginAndUpdateServerList(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+func TestNacosAuthClient_Login_InvalidSuccessResponses(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{"no accessToken", map[string]interface{}{constant.KEY_TOKEN_TTL: float64(10)}},
+		{"empty accessToken", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "", constant.KEY_TOKEN_TTL: float64(10)}},
+		{"non-string accessToken", map[string]interface{}{constant.KEY_ACCESS_TOKEN: float64(123), constant.KEY_TOKEN_TTL: float64(10)}},
+		{"missing tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok"}},
+		{"zero tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok", constant.KEY_TOKEN_TTL: float64(0)}},
+		{"negative tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok", constant.KEY_TOKEN_TTL: float64(-5)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAgent := &MockHttpAgent{
+				PostFunc: func(url string, header http.Header, timeoutMs uint64, params map[string]string) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: constant.RESPONSE_CODE_SUCCESS,
+						Body:       NewMockResponseBody(tc.body),
+					}, nil
+				},
+			}
+			client := NewNacosAuthClient(
+				constant.ClientConfig{Username: "u", Password: "p"},
+				[]constant.ServerConfig{{IpAddr: "localhost"}},
+				mockAgent,
+			)
+			success, err := client.Login()
+			assert.False(t, success, "invalid success response must not report success")
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, ErrLoginFailed), "invalid success response should wrap ErrLoginFailed")
+			assert.Empty(t, client.GetAccessToken(), "no token should be stored")
+		})
+	}
+}
+
+func TestNacosAuthClient_Login_ValidResponseStillSucceeds(t *testing.T) {
+	mockAgent := &MockHttpAgent{
+		PostFunc: func(url string, header http.Header, timeoutMs uint64, params map[string]string) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: constant.RESPONSE_CODE_SUCCESS,
+				Body: NewMockResponseBody(map[string]interface{}{
+					constant.KEY_ACCESS_TOKEN: "valid-token",
+					constant.KEY_TOKEN_TTL:    float64(18000),
+				}),
+			}, nil
+		},
+	}
+	client := NewNacosAuthClient(
+		constant.ClientConfig{Username: "u", Password: "p"},
+		[]constant.ServerConfig{{IpAddr: "localhost"}},
+		mockAgent,
+	)
+	success, err := client.Login()
+	assert.True(t, success)
+	assert.NoError(t, err)
+	assert.Equal(t, "valid-token", client.GetAccessToken())
+}

--- a/common/security/nacos_auth_client_test.go
+++ b/common/security/nacos_auth_client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -284,6 +285,7 @@ func TestNacosAuthClient_LoginFailure(t *testing.T) {
 
 	success, err := client.Login()
 	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrLoginFailed), "401 must be classified as credential error")
 	assert.False(t, success)
 	assert.Empty(t, client.GetAccessToken())
 }

--- a/common/security/nacos_auth_client_test.go
+++ b/common/security/nacos_auth_client_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -361,6 +362,7 @@ func TestNacosAuthClient_Login_InvalidSuccessResponses(t *testing.T) {
 		{"missing tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok"}},
 		{"zero tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok", constant.KEY_TOKEN_TTL: float64(0)}},
 		{"negative tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok", constant.KEY_TOKEN_TTL: float64(-5)}},
+		{"sub-second tokenTtl", map[string]interface{}{constant.KEY_ACCESS_TOKEN: "tok", constant.KEY_TOKEN_TTL: float64(0.5)}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -458,4 +460,65 @@ func TestNacosAuthClient_NextRefreshDelay_FutureDeadline(t *testing.T) {
 	delay := client.nextRefreshDelay()
 	assert.True(t, delay == 5*time.Second || delay == 4*time.Second,
 		"expected ~5s anchored to lastRefreshTime, got %v (the old ttl-window rule would give 9s)", delay)
+}
+
+func TestNacosAuthClient_Login_ErrorDoesNotLeakAccessToken(t *testing.T) {
+	const secret = "super-secret-access-token"
+	mockAgent := &MockHttpAgent{
+		PostFunc: func(url string, header http.Header, timeoutMs uint64, params map[string]string) (*http.Response, error) {
+			// A usable accessToken but no tokenTtl: rejected on the ttl check, at
+			// which point the raw body still carries a valid token.
+			return &http.Response{
+				StatusCode: constant.RESPONSE_CODE_SUCCESS,
+				Body:       NewMockResponseBody(map[string]interface{}{constant.KEY_ACCESS_TOKEN: secret}),
+			}, nil
+		},
+	}
+	client := NewNacosAuthClient(
+		constant.ClientConfig{Username: "u", Password: "p"},
+		[]constant.ServerConfig{{IpAddr: "localhost"}},
+		mockAgent,
+	)
+
+	success, err := client.Login()
+	assert.False(t, success)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrLoginFailed))
+	assert.NotContains(t, err.Error(), secret,
+		"the login error is logged by SecurityProxy/AutoRefresh and must not leak the access token")
+}
+
+func TestNacosAuthClient_Login_PreservesCredentialErrorAcrossServers(t *testing.T) {
+	// 10.0.0.1 rejects the credentials (401 -> ErrLoginFailed);
+	// 10.0.0.2 is unreachable (transport error, stays transient).
+	newClient := func(servers []constant.ServerConfig) *NacosAuthClient {
+		agent := &MockHttpAgent{
+			PostFunc: func(url string, header http.Header, timeoutMs uint64, params map[string]string) (*http.Response, error) {
+				if strings.Contains(url, "10.0.0.1") {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body:       NewMockResponseBody("unknown user!"),
+					}, nil
+				}
+				return nil, errors.New("dial tcp 10.0.0.2:8848: connect: connection refused")
+			},
+		}
+		return NewNacosAuthClient(constant.ClientConfig{Username: "u", Password: "p"}, servers, agent)
+	}
+
+	t.Run("credential first then transport", func(t *testing.T) {
+		client := newClient([]constant.ServerConfig{{IpAddr: "10.0.0.1"}, {IpAddr: "10.0.0.2"}})
+		success, err := client.Login()
+		assert.False(t, success)
+		assert.True(t, errors.Is(err, ErrLoginFailed),
+			"a credential failure must survive a later transport error, got %v", err)
+	})
+
+	t.Run("transport first then credential", func(t *testing.T) {
+		client := newClient([]constant.ServerConfig{{IpAddr: "10.0.0.2"}, {IpAddr: "10.0.0.1"}})
+		success, err := client.Login()
+		assert.False(t, success)
+		assert.True(t, errors.Is(err, ErrLoginFailed),
+			"a credential failure must be reported regardless of server order, got %v", err)
+	})
 }

--- a/common/security/nacos_auth_client_test.go
+++ b/common/security/nacos_auth_client_test.go
@@ -382,6 +382,9 @@ func TestNacosAuthClient_Login_InvalidSuccessResponses(t *testing.T) {
 			assert.Error(t, err)
 			assert.True(t, errors.Is(err, ErrLoginFailed), "invalid success response should wrap ErrLoginFailed")
 			assert.Empty(t, client.GetAccessToken(), "no token should be stored")
+
+			_, armed := client.refreshDeadlineUnix()
+			assert.False(t, armed, "a rejected login response must not arm the refresh state")
 		})
 	}
 }
@@ -439,4 +442,20 @@ func TestNacosAuthClient_NextRefreshDelay_ClampsPastDeadline(t *testing.T) {
 	client.tokenRefreshWindow = 1
 	client.mux.Unlock()
 	assert.Equal(t, minRefreshDelay, client.nextRefreshDelay(), "a passed deadline must not spin the timer")
+}
+
+func TestNacosAuthClient_NextRefreshDelay_FutureDeadline(t *testing.T) {
+	client := NewNacosAuthClient(constant.ClientConfig{Username: "u"}, nil, nil)
+	now := time.Now().Unix()
+	client.mux.Lock()
+	client.lastRefreshTime = now - 3
+	client.tokenTtl = 10
+	client.tokenRefreshWindow = 1
+	client.mux.Unlock()
+
+	// deadline = lastRefreshTime + ttl - 2*window = (now-3) + 8 = now + 5.
+	// The old, buggy rule scheduled ttl-window = 9s from now instead.
+	delay := client.nextRefreshDelay()
+	assert.True(t, delay == 5*time.Second || delay == 4*time.Second,
+		"expected ~5s anchored to lastRefreshTime, got %v (the old ttl-window rule would give 9s)", delay)
 }

--- a/common/security/nacos_auth_client_test.go
+++ b/common/security/nacos_auth_client_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -288,4 +289,63 @@ func TestNacosAuthClient_LoginFailure(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrLoginFailed), "401 must be classified as credential error")
 	assert.False(t, success)
 	assert.Empty(t, client.GetAccessToken())
+}
+
+func TestNacosAuthClient_ConcurrentLoginAndUpdateServerList(t *testing.T) {
+	mockAgent := &MockHttpAgent{
+		PostFunc: func(url string, header http.Header, timeoutMs uint64, params map[string]string) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: constant.RESPONSE_CODE_SUCCESS,
+				Body: NewMockResponseBody(map[string]interface{}{
+					constant.KEY_ACCESS_TOKEN: "concurrent-token",
+					constant.KEY_TOKEN_TTL:    float64(10),
+				}),
+			}, nil
+		},
+	}
+	client := NewNacosAuthClient(
+		constant.ClientConfig{Username: "u", Password: "p"},
+		[]constant.ServerConfig{{IpAddr: "localhost"}},
+		mockAgent,
+	)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				client.UpdateServerList([]constant.ServerConfig{{IpAddr: "127.0.0.1"}, {IpAddr: "localhost"}})
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = client.Login()
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = client.GetServerList()
+			}
+		}
+	}()
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }

--- a/common/security/ram_auth_client.go
+++ b/common/security/ram_auth_client.go
@@ -2,8 +2,11 @@ package security
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
+	"github.com/nacos-group/nacos-sdk-go/v3/common/logger"
 )
 
 type RamContext struct {
@@ -18,7 +21,13 @@ type RamAuthClient struct {
 	clientConfig           constant.ClientConfig
 	ramCredentialProviders []RamCredentialProvider
 	resourceInjector       map[string]ResourceInjector
-	matchedProvider        RamCredentialProvider
+	// matchedProvider and initialized are read by GetSecurityInfo on every
+	// request while AutoRefresh's retry goroutine may still be initializing,
+	// so both are guarded by mux.
+	matchedProvider RamCredentialProvider
+	initialized     bool
+	initRetryDelay  time.Duration
+	mux             sync.Mutex
 }
 
 func NewRamAuthClient(clientCfg constant.ClientConfig) *RamAuthClient {
@@ -53,6 +62,7 @@ func NewRamAuthClient(clientCfg constant.ClientConfig) *RamAuthClient {
 		clientConfig:           clientCfg,
 		ramCredentialProviders: providers,
 		resourceInjector:       injectors,
+		initRetryDelay:         retryDelay,
 	}
 }
 
@@ -66,28 +76,51 @@ func NewRamAuthClientWithProvider(clientCfg constant.ClientConfig, ramCredential
 }
 
 func (rac *RamAuthClient) Login() (bool, error) {
-	for _, provider := range rac.ramCredentialProviders {
-		if provider.MatchProvider() {
-			rac.matchedProvider = provider
-			break
+	rac.mux.Lock()
+	provider, initialized := rac.matchedProvider, rac.initialized
+	rac.mux.Unlock()
+
+	// Initialization already succeeded; per-request credentials come from
+	// GetCredentialsForNacosClient, so there is nothing to redo here.
+	if initialized {
+		return true, nil
+	}
+
+	if provider == nil {
+		for _, candidate := range rac.ramCredentialProviders {
+			if candidate.MatchProvider() {
+				provider = candidate
+				break
+			}
 		}
+		if provider == nil {
+			return false, nil
+		}
+		rac.mux.Lock()
+		rac.matchedProvider = provider
+		rac.mux.Unlock()
 	}
-	if rac.matchedProvider == nil {
-		return false, nil
-	}
-	err := rac.matchedProvider.Init()
-	if err != nil {
+
+	if err := provider.Init(); err != nil {
 		return false, err
 	}
+	rac.mux.Lock()
+	rac.initialized = true
+	rac.mux.Unlock()
 	return true, nil
 }
 
 func (rac *RamAuthClient) GetSecurityInfo(resource RequestResource) map[string]string {
 	var securityInfo = make(map[string]string, 4)
-	if rac.matchedProvider == nil {
+	rac.mux.Lock()
+	provider, initialized := rac.matchedProvider, rac.initialized
+	rac.mux.Unlock()
+	// Never sign with a provider whose Init has not succeeded: it would produce
+	// an empty RamContext and silently unsigned requests.
+	if provider == nil || !initialized {
 		return securityInfo
 	}
-	ramContext := rac.matchedProvider.GetCredentialsForNacosClient()
+	ramContext := provider.GetCredentialsForNacosClient()
 	rac.resourceInjector[resource.requestType].doInject(resource, ramContext, securityInfo)
 	return securityInfo
 }
@@ -96,9 +129,34 @@ func (rac *RamAuthClient) UpdateServerList(serverList []constant.ServerConfig) {
 	return
 }
 
-// AutoRefresh is a no-op: RAM/STS credentials are refreshed lazily by the
-// matched provider on each GetSecurityInfo call, so there is no background
-// token to renew here.
+// AutoRefresh retries a failed provider initialization until it succeeds, then
+// stops. There is no background token to renew — RAM/STS credentials are
+// resolved per request by GetCredentialsForNacosClient — but Init can fail
+// transiently at startup, and without a retry the client would keep signing
+// with an uninitialized provider.
 func (rac *RamAuthClient) AutoRefresh(ctx context.Context) {
-	return
+	go func() {
+		timer := time.NewTimer(rac.initRetryDelay)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				rac.mux.Lock()
+				provider, initialized := rac.matchedProvider, rac.initialized
+				rac.mux.Unlock()
+				// Nothing to retry: no provider matched, or Init already succeeded.
+				if provider == nil || initialized {
+					return
+				}
+				if _, err := rac.Login(); err != nil {
+					logger.Warnf("ram credential provider initialization failed, will retry: %v", err)
+					timer.Reset(rac.initRetryDelay)
+					continue
+				}
+				return
+			}
+		}
+	}()
 }

--- a/common/security/ram_auth_client.go
+++ b/common/security/ram_auth_client.go
@@ -1,6 +1,8 @@
 package security
 
 import (
+	"context"
+
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
 )
 
@@ -91,5 +93,12 @@ func (rac *RamAuthClient) GetSecurityInfo(resource RequestResource) map[string]s
 }
 
 func (rac *RamAuthClient) UpdateServerList(serverList []constant.ServerConfig) {
+	return
+}
+
+// AutoRefresh is a no-op: RAM/STS credentials are refreshed lazily by the
+// matched provider on each GetSecurityInfo call, so there is no background
+// token to renew here.
+func (rac *RamAuthClient) AutoRefresh(ctx context.Context) {
 	return
 }

--- a/common/security/ram_auth_client_test.go
+++ b/common/security/ram_auth_client_test.go
@@ -18,9 +18,13 @@ package security
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
+	"github.com/stretchr/testify/assert"
 )
 
 // Compile-time assertion that both auth clients satisfy AuthClient.
@@ -29,10 +33,132 @@ var (
 	_ AuthClient = (*RamAuthClient)(nil)
 )
 
-func TestRamAuthClient_AutoRefresh_NoOp(t *testing.T) {
+// stubRamProvider is a RamCredentialProvider whose Init() fails the first
+// failTimes calls and succeeds afterwards, counting both Init() and
+// credential lookups so tests can observe the initialization lifecycle.
+type stubRamProvider struct {
+	mux       sync.Mutex
+	matches   bool
+	failTimes int
+	initCalls int
+	credCalls int
+}
+
+func (s *stubRamProvider) MatchProvider() bool { return s.matches }
+
+func (s *stubRamProvider) Init() error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.initCalls++
+	if s.initCalls <= s.failTimes {
+		return errors.New("stub provider init failed")
+	}
+	return nil
+}
+
+func (s *stubRamProvider) GetCredentialsForNacosClient() RamContext {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.credCalls++
+	return RamContext{AccessKey: "ak", SecretKey: "sk"}
+}
+
+func (s *stubRamProvider) inits() int {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	return s.initCalls
+}
+
+func (s *stubRamProvider) creds() int {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	return s.credCalls
+}
+
+func newStubbedRamClient(provider RamCredentialProvider, retry time.Duration) *RamAuthClient {
+	client := NewRamAuthClient(constant.ClientConfig{})
+	client.ramCredentialProviders = []RamCredentialProvider{provider}
+	client.initRetryDelay = retry
+	return client
+}
+
+func TestRamAuthClient_AutoRefresh_NoProviderIsNoOp(t *testing.T) {
 	client := NewRamAuthClient(constant.ClientConfig{})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// Must not panic or block.
+	// Nothing matched, so there is nothing to retry: must not panic or block.
 	client.AutoRefresh(ctx)
+}
+
+func TestRamAuthClient_UninitializedProviderIsNotExposed(t *testing.T) {
+	provider := &stubRamProvider{matches: true, failTimes: 1}
+	client := newStubbedRamClient(provider, 20*time.Millisecond)
+
+	success, err := client.Login()
+	assert.False(t, success)
+	assert.Error(t, err)
+	assert.Equal(t, 1, provider.inits())
+
+	client.GetSecurityInfo(BuildNamingResource("ns", "group", "svc"))
+	assert.Equal(t, 0, provider.creds(),
+		"a provider whose Init failed must not be consulted for credentials")
+}
+
+func TestRamAuthClient_AutoRefresh_RetriesFailedInit(t *testing.T) {
+	provider := &stubRamProvider{matches: true, failTimes: 1}
+	client := newStubbedRamClient(provider, 20*time.Millisecond)
+
+	success, err := client.Login()
+	assert.False(t, success)
+	assert.Error(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.AutoRefresh(ctx)
+
+	assert.Eventually(t, func() bool { return provider.inits() >= 2 },
+		3*time.Second, 10*time.Millisecond, "a failed Init must be retried")
+
+	assert.Eventually(t, func() bool {
+		client.GetSecurityInfo(BuildNamingResource("ns", "group", "svc"))
+		return provider.creds() > 0
+	}, 3*time.Second, 20*time.Millisecond,
+		"after Init finally succeeds the provider must be usable")
+}
+
+func TestRamAuthClient_AutoRefresh_StopsAfterSuccessfulInit(t *testing.T) {
+	provider := &stubRamProvider{matches: true} // Init succeeds on the first call
+	client := newStubbedRamClient(provider, 20*time.Millisecond)
+
+	success, err := client.Login()
+	assert.True(t, success)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, provider.inits())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.AutoRefresh(ctx)
+
+	time.Sleep(200 * time.Millisecond) // several retry intervals
+	assert.Equal(t, 1, provider.inits(),
+		"Init must not run again once initialization has succeeded")
+}
+
+func TestRamAuthClient_AutoRefresh_StopsOnContextCancel(t *testing.T) {
+	provider := &stubRamProvider{matches: true, failTimes: 1 << 30} // never succeeds
+	client := newStubbedRamClient(provider, 20*time.Millisecond)
+
+	_, err := client.Login()
+	assert.Error(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client.AutoRefresh(ctx)
+	time.Sleep(100 * time.Millisecond) // let it retry a few times
+	cancel()
+
+	time.Sleep(60 * time.Millisecond) // let any in-flight retry finish
+	settled := provider.inits()
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, settled, provider.inits(),
+		"retries must stop once the context is cancelled")
 }

--- a/common/security/ram_auth_client_test.go
+++ b/common/security/ram_auth_client_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
+)
+
+// Compile-time assertion that both auth clients satisfy AuthClient.
+var (
+	_ AuthClient = (*NacosAuthClient)(nil)
+	_ AuthClient = (*RamAuthClient)(nil)
+)
+
+func TestRamAuthClient_AutoRefresh_NoOp(t *testing.T) {
+	client := NewRamAuthClient(constant.ClientConfig{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Must not panic or block.
+	client.AutoRefresh(ctx)
+}

--- a/common/security/security_proxy.go
+++ b/common/security/security_proxy.go
@@ -102,6 +102,7 @@ func BuildNamingResource(namespace, group, serviceName string) RequestResource {
 
 type AuthClient interface {
 	Login() (bool, error)
+	AutoRefresh(ctx context.Context)
 	GetSecurityInfo(resource RequestResource) map[string]string
 	UpdateServerList(serverList []constant.ServerConfig)
 }

--- a/common/security/security_proxy.go
+++ b/common/security/security_proxy.go
@@ -18,7 +18,7 @@ package security
 
 import (
 	"context"
-	"time"
+	"errors"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/http_agent"
@@ -111,13 +111,23 @@ type SecurityProxy struct {
 	Clients []AuthClient
 }
 
-func (sp *SecurityProxy) Login() {
+func (sp *SecurityProxy) Login() error {
+	var credentialErr error
 	for _, client := range sp.Clients {
 		_, err := client.Login()
-		if err != nil {
-			logger.Errorf("login in err:%v", err)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, ErrLoginFailed) {
+			logger.Errorf("nacos auth login failed, please check username/password: %v", err)
+			if credentialErr == nil {
+				credentialErr = err
+			}
+		} else {
+			logger.Warnf("nacos auth login transient error, will retry: %v", err)
 		}
 	}
+	return credentialErr
 }
 
 func (sp *SecurityProxy) GetSecurityInfo(resource RequestResource) map[string]string {
@@ -140,19 +150,9 @@ func (sp *SecurityProxy) UpdateServerList(serverList []constant.ServerConfig) {
 }
 
 func (sp *SecurityProxy) AutoRefresh(ctx context.Context) {
-	go func() {
-		var timer = time.NewTimer(time.Second * time.Duration(5))
-		defer timer.Stop()
-		for {
-			select {
-			case <-timer.C:
-				sp.Login()
-				timer.Reset(time.Second * time.Duration(5))
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
+	for _, client := range sp.Clients {
+		client.AutoRefresh(ctx)
+	}
 }
 
 func NewSecurityProxy(clientCfg constant.ClientConfig, serverCfgs []constant.ServerConfig, agent http_agent.IHttpAgent) SecurityProxy {

--- a/common/security/security_proxy_test.go
+++ b/common/security/security_proxy_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubAuthClient is a minimal AuthClient for exercising SecurityProxy
+// aggregation and delegation logic.
+type stubAuthClient struct {
+	loginErr    error
+	refreshedCh chan struct{}
+}
+
+func (s *stubAuthClient) Login() (bool, error) {
+	return s.loginErr == nil, s.loginErr
+}
+func (s *stubAuthClient) AutoRefresh(ctx context.Context) {
+	if s.refreshedCh != nil {
+		close(s.refreshedCh)
+	}
+}
+func (s *stubAuthClient) GetSecurityInfo(resource RequestResource) map[string]string {
+	return map[string]string{}
+}
+func (s *stubAuthClient) UpdateServerList(serverList []constant.ServerConfig) {}
+
+func TestSecurityProxy_Login_ReturnsCredentialError(t *testing.T) {
+	credErr := classifyLoginStatus(401, "unknown user!")
+	sp := SecurityProxy{Clients: []AuthClient{
+		&stubAuthClient{loginErr: errors.New("network down")}, // transient, not returned
+		&stubAuthClient{loginErr: credErr},                    // credential, returned
+	}}
+	err := sp.Login()
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrLoginFailed))
+}
+
+func TestSecurityProxy_Login_AllSuccess(t *testing.T) {
+	sp := SecurityProxy{Clients: []AuthClient{
+		&stubAuthClient{loginErr: nil},
+		&stubAuthClient{loginErr: nil},
+	}}
+	assert.NoError(t, sp.Login())
+}
+
+func TestSecurityProxy_Login_TransientOnlyIsNil(t *testing.T) {
+	sp := SecurityProxy{Clients: []AuthClient{
+		&stubAuthClient{loginErr: errors.New("connection refused")},
+	}}
+	// Transient errors must not surface as a fail-fast credential error.
+	assert.NoError(t, sp.Login())
+}
+
+func TestSecurityProxy_AutoRefresh_DelegatesToClients(t *testing.T) {
+	ch := make(chan struct{})
+	sp := SecurityProxy{Clients: []AuthClient{&stubAuthClient{refreshedCh: ch}}}
+	sp.AutoRefresh(context.Background())
+	select {
+	case <-ch:
+	default:
+		t.Fatal("AutoRefresh should delegate to each client's AutoRefresh")
+	}
+}

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/clients"
+	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
+	"github.com/nacos-group/nacos-sdk-go/v3/vo"
+)
+
+// TestIntegrationAuth_WrongPasswordFailFast verifies that with
+// FailOnAuthError enabled, a wrong password makes NewConfigClient return an
+// error instead of silently constructing an unusable client (#670).
+func TestIntegrationAuth_WrongPasswordFailFast(t *testing.T) {
+	port, err := strconv.ParseUint(envOr("NACOS_SERVER_PORT", "8848"), 10, 64)
+	require.NoError(t, err, "invalid NACOS_SERVER_PORT")
+
+	sc := []constant.ServerConfig{
+		*constant.NewServerConfig(envOr("NACOS_SERVER_IP", "127.0.0.1"), port,
+			constant.WithContextPath("/nacos")),
+	}
+	cc := *constant.NewClientConfig(
+		constant.WithNamespaceId(""),
+		constant.WithUsername(envOr("NACOS_USERNAME", "nacos")),
+		constant.WithPassword("definitely-wrong-password"),
+		constant.WithTimeoutMs(10000),
+		constant.WithNotLoadCacheAtStart(true),
+		constant.WithFailOnAuthError(true),
+		constant.WithLogDir(t.TempDir()),
+		constant.WithCacheDir(t.TempDir()),
+		constant.WithLogLevel("warn"),
+	)
+
+	_, err = clients.NewConfigClient(vo.NacosClientParam{
+		ClientConfig:  &cc,
+		ServerConfigs: sc,
+	})
+	assert.Error(t, err, "wrong password with FailOnAuthError must fail NewConfigClient")
+}
+
+// TestIntegrationAuth_WrongPasswordDefaultNoFailFast verifies backward-compatible
+// behavior: without FailOnAuthError, construction does not abort on bad
+// credentials (the error only surfaces later on business requests).
+func TestIntegrationAuth_WrongPasswordDefaultNoFailFast(t *testing.T) {
+	port, err := strconv.ParseUint(envOr("NACOS_SERVER_PORT", "8848"), 10, 64)
+	require.NoError(t, err, "invalid NACOS_SERVER_PORT")
+
+	sc := []constant.ServerConfig{
+		*constant.NewServerConfig(envOr("NACOS_SERVER_IP", "127.0.0.1"), port,
+			constant.WithContextPath("/nacos")),
+	}
+	cc := *constant.NewClientConfig(
+		constant.WithNamespaceId(""),
+		constant.WithUsername(envOr("NACOS_USERNAME", "nacos")),
+		constant.WithPassword("definitely-wrong-password"),
+		constant.WithTimeoutMs(10000),
+		constant.WithNotLoadCacheAtStart(true),
+		constant.WithLogDir(t.TempDir()),
+		constant.WithCacheDir(t.TempDir()),
+		constant.WithLogLevel("warn"),
+	)
+
+	client, err := clients.NewConfigClient(vo.NacosClientParam{
+		ClientConfig:  &cc,
+		ServerConfigs: sc,
+	})
+	assert.NoError(t, err, "default behavior must not abort construction on bad credentials")
+	assert.NotNil(t, client)
+}

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -86,6 +86,9 @@ func TestIntegrationAuth_WrongPasswordDefaultNoFailFast(t *testing.T) {
 		ClientConfig:  &cc,
 		ServerConfigs: sc,
 	})
-	assert.NoError(t, err, "default behavior must not abort construction on bad credentials")
-	assert.NotNil(t, client)
+	require.NoError(t, err, "default behavior must not abort construction on bad credentials")
+	require.NotNil(t, client)
+	// Close it: otherwise its auth refresh task keeps retrying the deliberately
+	// wrong password for the rest of the integration run.
+	defer client.CloseClient()
 }


### PR DESCRIPTION
## What this does

PR3 of the v3 upgrade roadmap (#879), the Auth layer. Builds on PR1 (#881) and PR2 (#897). Refactors `common/security` to expose login failures, refresh tokens by TTL, and eliminate data races — while keeping the existing `SecurityProxy`/`AuthClient` type names (incremental migration, no breaking rename).

### Changes
1. **Expose login errors (#670).** `SecurityProxy.Login()` now returns an aggregated `error`. New `ClientConfig.FailOnAuthError` (default `false`) makes `NewClient` fail fast when the initial login fails — i.e. **any non-200 response** from the auth endpoint, **or a 200 response carrying no usable token** (both surface as `errors.Is(err, security.ErrLoginFailed)`). Only **transport errors** (server unreachable) stay transient and keep retrying, so a K8s startup-ordering race never aborts construction. Level-graded logging (`Errorf` for login failures, `Warnf` for transient) lets users distinguish "wrong password" from "server unreachable" even without the flag.

   > **Why not just 401/403?** Probed against real servers: Nacos 2.5.2 returns **403** for a wrong password but **500** for an unknown user, while 3.2.0 is the **reverse**, and 3.x's 500 body carries no credential hint. No single input yields 401/403 on both versions, so a 401/403-only rule cannot reliably catch bad credentials. Any non-200 means no token was issued, so all are treated as a login failure.
2. **TTL-based refresh.** `AuthClient` gains `AutoRefresh(ctx)`; each client self-schedules — `NacosAuthClient` refreshes on a token-TTL timer, `RamAuthClient` is a no-op (RAM/STS signing happens per request). Removes `SecurityProxy`'s unconditional 5s polling loop.
3. **Concurrency safety.** `NacosAuthClient`'s refresh state (`lastRefreshTime`/`tokenTtl`/`tokenRefreshWindow`/`serverCfgs`) is now mutex-guarded; `accessToken` stays an `atomic.Value`; no lock is held across the login HTTP IO. Verified with a `-race` concurrent test.

### #807 / #728
Their core was already fixed on this branch by earlier commits (token-refresh loop: f1545e0; endpoint-mode login: #730). This PR adds regression tests and the error-exposure path; closing both on merge.

## Compatibility
- **Default behavior unchanged**: `FailOnAuthError=false` keeps the current "log and continue" behavior for existing users.
- **`AuthClient` interface** gained `AutoRefresh(ctx)` and `Login()`'s return type changed — a breaking change for any external implementer of this interface. v3 is a new module path with no existing external implementations; all in-repo callers are updated.

## Incidental fix (outside the auth layer)

`common/remote/rpc/rpc_client.go` read `rpcClientStatus` non-atomically in `Request()`'s not-connected path (via the value-receiver `getDesc()`, which copies the field), while every other access to that field uses `CompareAndSwapInt32` / `StoreInt32` / `LoadInt32`. When a request runs concurrently with `reconnect()` storing a new status, `-race` flags it — this intermittently failed the `TestIntegrationReconnect` job on the Nacos 2.x runner (~1 in 4 CI runs; not reproducible locally in 5 consecutive runs).

The line dates to 2022 and is the same class as the `currentConnection` data race fixed in #833, which missed this one read. It is unrelated to the auth changes, but it was blocking this PR's CI, so it is fixed here as a single-line change. Happy to split it into its own PR if you'd prefer.

## Non-goals
- No migration of auth to proto/gRPC (login is an HTTP channel by design).
- No changes to RAM/KMS credential-signing internals.
- Config/Naming module issues (#630/#733) are out of scope (separate PRs).

## Testing
- Unit: login success / non-200 classification / malformed-200 rejection (missing, empty or non-string `accessToken`; missing, zero, negative or sub-second `tokenTtl`); deterministic refresh-deadline and clamp tests; `FailOnAuthError` both sides; short-TTL auto-refresh actually fires (covers #807 regression); `UpdateServerList` ‖ `Login` ‖ `GetServerList` under `-race`; `SecurityProxy` aggregation semantics; `NewNacosServer` credential-abort via `httptest` 401.
- Integration (`//go:build integration`, CI Nacos 2.5.2 + 3.x, auth-enabled): wrong password + `FailOnAuthError=true` → `NewConfigClient` returns error; default → constructs a usable client.
- Local: `gofmt`/`goimports`/`go build`/`go vet` clean (one pre-existing unrelated `naming_http` vet warning); `go test ./common/... -race` all pass.

## Related
- Fixes #670
- Refs #807, #728 (regression coverage; closed on merge), #879 (roadmap), #898 (sub-issue)


