### PR TITLE
feat: migrate naming to sdk-proto and align instance redo semantics with the Java client

### DIFF
--- a/clients/naming_client/naming_client.go
+++ b/clients/naming_client/naming_client.go
@@ -375,12 +375,22 @@ func (sc *NamingClient) Unsubscribe(param *vo.SubscribeParam) (err error) {
 	if param.ServiceName == "" {
 		return errors.New("serviceName cannot be empty!")
 	}
+	if len(param.GroupName) == 0 {
+		param.GroupName = constant.DEFAULT_GROUP
+	}
 	clusterSelector := naming_cache.NewClusterSelector(param.Clusters)
 	callbackWrapper := naming_cache.NewSubscribeCallbackFuncWrapper(clusterSelector, &param.SubscribeCallback)
 	serviceFullName := util.GetGroupName(param.ServiceName, param.GroupName)
 	sc.serviceInfoHolder.DeregisterCallback(serviceFullName, "", callbackWrapper)
 	if !sc.serviceInfoHolder.IsSubscribed(serviceFullName, "") {
 		err = sc.serviceProxy.Unsubscribe(param.ServiceName, param.GroupName, "")
+		if err != nil {
+			// server-side unsubscribe failed: the server keeps pushing
+			// updates for this service, so keep the local callback alive
+			// instead of leaving it half-removed (registered nowhere but
+			// still receiving no explicit unsubscribe on the wire).
+			sc.serviceInfoHolder.RegisterCallback(serviceFullName, "", callbackWrapper)
+		}
 	}
 
 	return err

--- a/clients/naming_client/naming_client_test.go
+++ b/clients/naming_client/naming_client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v3/clients/nacos_client"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v3/model"
+	"github.com/nacos-group/nacos-sdk-go/v3/util"
 	"github.com/nacos-group/nacos-sdk-go/v3/vo"
 	"github.com/stretchr/testify/assert"
 )
@@ -628,4 +629,39 @@ func TestNamingClient_Unsubscribe_Integration_Test(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, mockProxy.unsubscribeCalled)
 
+}
+
+// TestNamingClient_Unsubscribe_EmptyGroupNormalized regression test: Subscribe
+// normalizes an empty group to DEFAULT_GROUP but Unsubscribe did not, so the
+// callback registered under DEFAULT_GROUP@@svc was never found when
+// unsubscribing with an empty group.
+func TestNamingClient_Unsubscribe_EmptyGroupNormalized(t *testing.T) {
+	callback := func(services []model.Instance, err error) {
+		// 空回调函数
+	}
+	param := &vo.SubscribeParam{
+		ServiceName:       "svc",
+		GroupName:         "",
+		SubscribeCallback: callback,
+	}
+
+	client := NewTestNamingClient()
+	mockProxy := client.serviceProxy.(*MockNamingProxy)
+
+	err := client.Subscribe(param)
+	assert.Nil(t, err)
+
+	// Subscribe normalizes param.GroupName to DEFAULT_GROUP as a side effect
+	// (param is a pointer), which would otherwise mask the bug under test.
+	// Reset it to "" so Unsubscribe is exercised with a genuinely empty
+	// group, matching real callers who unsubscribe with the empty group they
+	// originally configured.
+	param.GroupName = ""
+
+	err = client.Unsubscribe(param)
+	assert.Nil(t, err)
+
+	assert.True(t, mockProxy.unsubscribeCalled)
+	assert.Equal(t, []string{"svc", constant.DEFAULT_GROUP, ""}, mockProxy.unsubscribeParams)
+	assert.False(t, client.serviceInfoHolder.IsSubscribed(util.GetGroupName("svc", constant.DEFAULT_GROUP), ""))
 }

--- a/clients/naming_client/naming_client_test.go
+++ b/clients/naming_client/naming_client_test.go
@@ -17,6 +17,7 @@
 package naming_client
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/common/http_agent"
@@ -40,6 +41,7 @@ var serverConfigTest = *constant.NewServerConfig("127.0.0.1", 80, constant.WithC
 type MockNamingProxy struct {
 	unsubscribeCalled bool
 	unsubscribeParams []string // 记录调用参数
+	unsubscribeErr    error    // 注入 Unsubscribe 失败
 }
 
 func (m *MockNamingProxy) RegisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
@@ -73,7 +75,7 @@ func (m *MockNamingProxy) Subscribe(serviceName, groupName, clusters string) (mo
 func (m *MockNamingProxy) Unsubscribe(serviceName, groupName, clusters string) error {
 	m.unsubscribeCalled = true
 	m.unsubscribeParams = []string{serviceName, groupName, clusters}
-	return nil
+	return m.unsubscribeErr
 }
 
 func (m *MockNamingProxy) CloseClient() {}
@@ -664,4 +666,32 @@ func TestNamingClient_Unsubscribe_EmptyGroupNormalized(t *testing.T) {
 	assert.True(t, mockProxy.unsubscribeCalled)
 	assert.Equal(t, []string{"svc", constant.DEFAULT_GROUP, ""}, mockProxy.unsubscribeParams)
 	assert.False(t, client.serviceInfoHolder.IsSubscribed(util.GetGroupName("svc", constant.DEFAULT_GROUP), ""))
+}
+
+// When the server-side unsubscribe fails (transport error or a response the
+// server did not accept), the server keeps pushing for this subscription, so
+// the locally deregistered callback must be re-registered — otherwise pushes
+// arrive with no handler while the caller believes the subscription is still
+// active (their Unsubscribe returned an error).
+func TestNamingClient_Unsubscribe_RestoresCallbackOnProxyFailure(t *testing.T) {
+	callback := func(services []model.Instance, err error) {}
+	param := &vo.SubscribeParam{
+		ServiceName:       "svc-restore",
+		GroupName:         "g",
+		SubscribeCallback: callback,
+	}
+
+	client := NewTestNamingClient()
+	mockProxy := client.serviceProxy.(*MockNamingProxy)
+
+	err := client.Subscribe(param)
+	assert.Nil(t, err)
+	assert.True(t, client.serviceInfoHolder.IsSubscribed(util.GetGroupName("svc-restore", "g"), ""))
+
+	mockProxy.unsubscribeErr = errors.New("server rejected unsubscribe")
+	err = client.Unsubscribe(param)
+	assert.Error(t, err)
+	assert.True(t, mockProxy.unsubscribeCalled)
+	assert.True(t, client.serviceInfoHolder.IsSubscribed(util.GetGroupName("svc-restore", "g"), ""),
+		"callback must be restored when the server-side unsubscribe fails")
 }

--- a/clients/naming_client/naming_grpc/connection_event_listener.go
+++ b/clients/naming_client/naming_grpc/connection_event_listener.go
@@ -113,6 +113,20 @@ func (c *ConnectionEventListener) RemoveInstanceForRedo(serviceName, groupName s
 	c.registeredInstanceCached.Remove(key)
 }
 
+// GetBatchInstancesForRedo returns the cached batch-shape redo list for the
+// service, if and only if the service was last published via batch
+// registration. Mirrors Java's redoService.getRegisteredInstancesByKey +
+// instanceof BatchInstanceRedoData check.
+func (c *ConnectionEventListener) GetBatchInstancesForRedo(serviceName, groupName string) ([]model.Instance, bool) {
+	key := util.GetGroupName(serviceName, groupName)
+	v, ok := c.registeredInstanceCached.Get(key)
+	if !ok {
+		return nil, false
+	}
+	instances, ok := v.([]model.Instance)
+	return instances, ok
+}
+
 func (c *ConnectionEventListener) CacheSubscriberForRedo(fullServiceName, clusters string) {
 	key := util.GetServiceCacheKey(fullServiceName, clusters)
 	if !c.IsSubscriberCached(key) {

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy.go
@@ -113,6 +113,23 @@ func (proxy *NamingGrpcProxy) requestToServer(request rpc_request.IRequest) (rpc
 	return response, err
 }
 
+// maxInstancePort is the upper bound of the server's valid port range. The
+// proto wire carries ports as int32 while the public API exposes uint64: an
+// unchecked conversion would silently truncate an out-of-range value into a
+// different, valid port (2^32+80 becomes 80), so an invalid register or
+// deregister could operate on another live endpoint. The legacy JSON wire
+// sent the original value and let the server reject it; on the proto wire
+// the client must reject it before any redo-cache mutation or send.
+const maxInstancePort = 65535
+
+func validateInstancePort(serviceName string, instance model.Instance) error {
+	if instance.Port > maxInstancePort {
+		return errors.Errorf("invalid port %d for service %s instance %s: port must not exceed %d",
+			instance.Port, serviceName, instance.Ip, maxInstancePort)
+	}
+	return nil
+}
+
 // RegisterInstance registers one instance and caches it in single-request
 // shape for reconnect redo (Java parity: registerServiceForEphemeral). The
 // server keeps ONE publication per (connection, service) and a second
@@ -122,6 +139,9 @@ func (proxy *NamingGrpcProxy) requestToServer(request rpc_request.IRequest) (rpc
 func (proxy *NamingGrpcProxy) RegisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
 	logger.Infof("register instance namespaceId:<%s>,serviceName:<%s> with instance:<%s>",
 		proxy.clientConfig.NamespaceId, serviceName, util.ToJsonString(instance))
+	if err := validateInstancePort(serviceName, instance); err != nil {
+		return false, err
+	}
 	proxy.redoMu.Lock()
 	proxy.eventListener.CacheInstanceForRedo(serviceName, groupName, instance)
 	proxy.redoMu.Unlock()
@@ -143,6 +163,11 @@ func (proxy *NamingGrpcProxy) BatchRegisterInstance(serviceName string, groupNam
 	}
 	logger.Infof("batch register instance namespaceId:<%s>,serviceName:<%s> with instance:<%s>",
 		proxy.clientConfig.NamespaceId, serviceName, util.ToJsonString(instances))
+	for _, inst := range instances {
+		if err := validateInstancePort(serviceName, inst); err != nil {
+			return false, err
+		}
+	}
 	proxy.redoMu.Lock()
 	proxy.eventListener.CacheInstancesForRedo(serviceName, groupName, instances)
 	proxy.redoMu.Unlock()
@@ -161,13 +186,20 @@ func (proxy *NamingGrpcProxy) BatchRegisterInstance(serviceName string, groupNam
 // side no-op against batch shape, probe-verified 2.5.2/3.2.0). Only a
 // single-shape (or never-registered) service sends a plain deregister.
 //
-// redoMu is taken FIRST, before the shape check: this makes the check and the
-// subsequent cache mutation+send atomic with respect to concurrent
-// RegisterInstance/BatchRegisterInstance/DeregisterInstance calls, so there is
-// no shape-flip window to retry around (unlike a check-then-lock design).
+// redoMu is taken FIRST, before the shape check: this makes the shape check
+// and the subsequent CACHE mutation atomic with respect to the cache writes
+// of concurrent RegisterInstance/BatchRegisterInstance/DeregisterInstance
+// calls, so there is no shape-flip window to retry around (unlike a
+// check-then-lock design). As the struct-level redoMu comment notes, only
+// this deregister path holds the lock across its send; Register and
+// BatchRegister sends run outside the lock, so send ordering against them is
+// not guaranteed and reconverges via redo replay.
 func (proxy *NamingGrpcProxy) DeregisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
 	logger.Infof("deregister instance namespaceId:<%s>,serviceName:<%s> with instance:<%s:%d@%s>",
 		proxy.clientConfig.NamespaceId, serviceName, instance.Ip, instance.Port, instance.ClusterName)
+	if err := validateInstancePort(serviceName, instance); err != nil {
+		return false, err
+	}
 	proxy.redoMu.Lock()
 	if batchInstances, isBatch := proxy.eventListener.GetBatchInstancesForRedo(serviceName, groupName); isBatch {
 		defer proxy.redoMu.Unlock()

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy.go
@@ -265,6 +265,13 @@ func (proxy *NamingGrpcProxy) Unsubscribe(serviceName, groupName, clusters strin
 	proxy.eventListener.RemoveSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
 	_, err := proxy.send(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName,
 		clusters, false))
+	if err != nil {
+		// the server-side unsubscribe request failed, so the server keeps
+		// pushing updates for this subscription; restore the redo cache
+		// entry so a reconnect keeps re-subscribing until a later
+		// unsubscribe call actually succeeds.
+		proxy.eventListener.CacheSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
+	}
 	return err
 }
 

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/nacos-group/nacos-sdk-go/v3/clients/naming_client/naming_cache"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/logger"
@@ -263,12 +265,22 @@ func (proxy *NamingGrpcProxy) Unsubscribe(serviceName, groupName, clusters strin
 	logger.Infof("Unsubscribe Service namespaceId:<%s>, serviceName:<%s>, groupName:<%s>, clusters:<%s>",
 		proxy.clientConfig.NamespaceId, serviceName, groupName, clusters)
 	proxy.eventListener.RemoveSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
-	_, err := proxy.send(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName,
+	response, err := proxy.send(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName,
 		clusters, false))
+	if err == nil && response == nil {
+		err = errors.Errorf("unsubscribe %s got nil response", util.GetGroupName(serviceName, groupName))
+	}
+	if err == nil && !response.IsSuccess() {
+		// The rpc client returns (response, nil) for a response the server
+		// answered but did not accept; that is still a failed unsubscribe
+		// and must not be silently treated as success.
+		err = errors.Errorf("unsubscribe %s failed, resultCode:%d message:%s",
+			util.GetGroupName(serviceName, groupName), response.GetResultCode(), response.GetMessage())
+	}
 	if err != nil {
-		// the server-side unsubscribe request failed, so the server keeps
-		// pushing updates for this subscription; restore the redo cache
-		// entry so a reconnect keeps re-subscribing until a later
+		// the server-side unsubscribe did not take effect, so the server
+		// keeps pushing updates for this subscription; restore the redo
+		// cache entry so a reconnect keeps re-subscribing until a later
 		// unsubscribe call actually succeeds.
 		proxy.eventListener.CacheSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
 	}

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy.go
@@ -53,8 +53,15 @@ type NamingGrpcProxy struct {
 	// the instance redo cache across RegisterInstance, BatchRegisterInstance,
 	// and DeregisterInstance. The batch-deregister path additionally holds it
 	// across the republish send, mirroring Java NamingGrpcClientProxy's
-	// batchDeregisterService, so a concurrent register cannot interleave
-	// between the retained-set computation and its publication.
+	// batchDeregisterService, so a concurrent register's cache write cannot
+	// interleave between the retained-set computation and the cache write it
+	// is derived from. Send ordering is NOT guaranteed: Register and
+	// BatchRegister release the mutex before sending, so a request already in
+	// flight when a deregister runs can still land afterwards and leave the
+	// server briefly different from the redo cache — the same inversion
+	// exists in Java, where doRegisterService/doBatchRegisterService also run
+	// outside the monitor; the redo replay reconverges the server on the next
+	// reconnect.
 	redoMu sync.Mutex
 }
 

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy.go
@@ -18,6 +18,7 @@ package naming_grpc
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/clients/naming_client/naming_cache"
@@ -41,6 +42,18 @@ type NamingGrpcProxy struct {
 	rpcClient         rpc.IRpcClient
 	eventListener     *ConnectionEventListener
 	serviceInfoHolder *naming_cache.ServiceInfoHolder
+	// send performs the actual server round-trip; it defaults to
+	// requestToServer and is swapped out in tests so the request sequence can
+	// be asserted without a live rpc client.
+	send func(request rpc_request.IRequest) (rpc_response.IResponse, error)
+	// redoMu is the redo-cache monitor: it mirrors Java NamingGrpcRedoService's
+	// synchronized(registeredInstances), serializing every read-modify-write of
+	// the instance redo cache across RegisterInstance, BatchRegisterInstance,
+	// and DeregisterInstance. The batch-deregister path additionally holds it
+	// across the republish send, mirroring Java NamingGrpcClientProxy's
+	// batchDeregisterService, so a concurrent register cannot interleave
+	// between the retained-set computation and its publication.
+	redoMu sync.Mutex
 }
 
 // NewNamingGrpcProxy create naming grpc proxy
@@ -51,6 +64,7 @@ func NewNamingGrpcProxy(ctx context.Context, clientCfg constant.ClientConfig, na
 		nacosServer:       nacosServer,
 		serviceInfoHolder: serviceInfoHolder,
 	}
+	srvProxy.send = srvProxy.requestToServer
 
 	uid, err := uuid.NewV4()
 	if err != nil {
@@ -90,43 +104,99 @@ func (proxy *NamingGrpcProxy) requestToServer(request rpc_request.IRequest) (rpc
 	return response, err
 }
 
-// RegisterInstance ...
+// RegisterInstance registers one instance and caches it in single-request
+// shape for reconnect redo (Java parity: registerServiceForEphemeral). The
+// server keeps ONE publication per (connection, service) and a second
+// registerInstance on the same client REPLACES it (verified on Nacos
+// 2.5.2/3.1.0/3.2.0, issue #866): to publish several instances of one
+// service from one client, use BatchRegisterInstance.
 func (proxy *NamingGrpcProxy) RegisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
 	logger.Infof("register instance namespaceId:<%s>,serviceName:<%s> with instance:<%s>",
 		proxy.clientConfig.NamespaceId, serviceName, util.ToJsonString(instance))
+	proxy.redoMu.Lock()
 	proxy.eventListener.CacheInstanceForRedo(serviceName, groupName, instance)
+	proxy.redoMu.Unlock()
 	instanceRequest := rpc_request.NewInstanceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, "registerInstance", instance)
-	response, err := proxy.requestToServer(instanceRequest)
+	response, err := proxy.send(instanceRequest)
 	if err != nil {
 		return false, err
 	}
-	return response.IsSuccess(), err
+	return response.IsSuccess(), nil
 }
 
-// BatchRegisterInstance ...
+// BatchRegisterInstance wholesale-replaces the service publication and caches
+// the list in batch shape for redo. instances may legally be empty ([] clears
+// the publication server-side, probe-verified 2.5.2/3.2.0) but must not be
+// nil: nil marshals to JSON null, which 3.x rejects with an NPE.
 func (proxy *NamingGrpcProxy) BatchRegisterInstance(serviceName string, groupName string, instances []model.Instance) (bool, error) {
+	if instances == nil {
+		instances = make([]model.Instance, 0)
+	}
 	logger.Infof("batch register instance namespaceId:<%s>,serviceName:<%s> with instance:<%s>",
 		proxy.clientConfig.NamespaceId, serviceName, util.ToJsonString(instances))
+	proxy.redoMu.Lock()
 	proxy.eventListener.CacheInstancesForRedo(serviceName, groupName, instances)
+	proxy.redoMu.Unlock()
 	batchInstanceRequest := rpc_request.NewBatchInstanceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, "batchRegisterInstance", instances)
-	response, err := proxy.requestToServer(batchInstanceRequest)
+	response, err := proxy.send(batchInstanceRequest)
 	if err != nil {
 		return false, err
 	}
-	return response.IsSuccess(), err
+	return response.IsSuccess(), nil
 }
 
-// DeregisterInstance ...
+// DeregisterInstance mirrors Java's deregisterServiceForEphemeral: when the
+// service was last published in batch shape, the instance is removed from the
+// retained list and the remainder is re-published as a batch (a plain
+// deregisterInstance can never shrink a batch publication - it is a server-
+// side no-op against batch shape, probe-verified 2.5.2/3.2.0). Only a
+// single-shape (or never-registered) service sends a plain deregister.
+//
+// redoMu is taken FIRST, before the shape check: this makes the check and the
+// subsequent cache mutation+send atomic with respect to concurrent
+// RegisterInstance/BatchRegisterInstance/DeregisterInstance calls, so there is
+// no shape-flip window to retry around (unlike a check-then-lock design).
 func (proxy *NamingGrpcProxy) DeregisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
 	logger.Infof("deregister instance namespaceId:<%s>,serviceName:<%s> with instance:<%s:%d@%s>",
 		proxy.clientConfig.NamespaceId, serviceName, instance.Ip, instance.Port, instance.ClusterName)
-	instanceRequest := rpc_request.NewInstanceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, "deregisterInstance", instance)
-	response, err := proxy.requestToServer(instanceRequest)
+	proxy.redoMu.Lock()
+	if batchInstances, isBatch := proxy.eventListener.GetBatchInstancesForRedo(serviceName, groupName); isBatch {
+		defer proxy.redoMu.Unlock()
+		// Remove the first ip:port match from the retained batch (Java parity:
+		// getRetainInstance compares only Ip and Port and removes a single
+		// match) - unchanged when the instance is unknown, empty when it was
+		// the last member. The cache+send stays inline (rather than delegating
+		// to BatchRegisterInstance) because that method takes redoMu itself,
+		// and Go's sync.Mutex is not reentrant.
+		retained := make([]model.Instance, 0, len(batchInstances))
+		removed := false
+		for _, inst := range batchInstances {
+			if !removed && inst.Ip == instance.Ip && inst.Port == instance.Port {
+				removed = true
+				continue
+			}
+			retained = append(retained, inst)
+		}
+		// retained may legally be an empty (non-nil) slice after the last
+		// member is deregistered: the batch redo entry lingers rather than
+		// being deleted, mirroring Java - a later redo replay simply resends
+		// this harmless empty batch, which keeps the publication cleared.
+		proxy.eventListener.CacheInstancesForRedo(serviceName, groupName, retained)
+		batchInstanceRequest := rpc_request.NewBatchInstanceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, "batchRegisterInstance", retained)
+		response, err := proxy.send(batchInstanceRequest)
+		if err != nil {
+			return false, err
+		}
+		return response.IsSuccess(), nil
+	}
 	proxy.eventListener.RemoveInstanceForRedo(serviceName, groupName, instance)
+	proxy.redoMu.Unlock()
+	instanceRequest := rpc_request.NewInstanceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, "deregisterInstance", instance)
+	response, err := proxy.send(instanceRequest)
 	if err != nil {
 		return false, err
 	}
-	return response.IsSuccess(), err
+	return response.IsSuccess(), nil
 }
 
 // GetServiceList ...
@@ -140,7 +210,7 @@ func (proxy *NamingGrpcProxy) GetServiceList(pageNo uint32, pageSize uint32, gro
 			break
 		}
 	}
-	response, err := proxy.requestToServer(rpc_request.NewServiceListRequest(namespaceId, "",
+	response, err := proxy.send(rpc_request.NewServiceListRequest(namespaceId, "",
 		groupName, int(pageNo), int(pageSize), selectorStr))
 	if err != nil {
 		return model.ServiceList{}, err
@@ -159,7 +229,7 @@ func (proxy *NamingGrpcProxy) ServerHealthy() bool {
 
 // QueryInstancesOfService ...
 func (proxy *NamingGrpcProxy) QueryInstancesOfService(serviceName, groupName, cluster string, udpPort int, healthyOnly bool) (*model.Service, error) {
-	response, err := proxy.requestToServer(rpc_request.NewServiceQueryRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, cluster,
+	response, err := proxy.send(rpc_request.NewServiceQueryRequest(proxy.clientConfig.NamespaceId, serviceName, groupName, cluster,
 		healthyOnly, udpPort))
 	if err != nil {
 		return nil, err
@@ -180,7 +250,7 @@ func (proxy *NamingGrpcProxy) Subscribe(serviceName, groupName string, clusters 
 	request := rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName,
 		groupName, clusters, true)
 	request.Headers["app"] = proxy.clientConfig.AppName
-	response, err := proxy.requestToServer(request)
+	response, err := proxy.send(request)
 	if err != nil {
 		return model.Service{}, err
 	}
@@ -193,7 +263,7 @@ func (proxy *NamingGrpcProxy) Unsubscribe(serviceName, groupName, clusters strin
 	logger.Infof("Unsubscribe Service namespaceId:<%s>, serviceName:<%s>, groupName:<%s>, clusters:<%s>",
 		proxy.clientConfig.NamespaceId, serviceName, groupName, clusters)
 	proxy.eventListener.RemoveSubscriberForRedo(util.GetGroupName(serviceName, groupName), clusters)
-	_, err := proxy.requestToServer(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName,
+	_, err := proxy.send(rpc_request.NewSubscribeServiceRequest(proxy.clientConfig.NamespaceId, serviceName, groupName,
 		clusters, false))
 	return err
 }

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
@@ -347,3 +347,24 @@ func TestUnsubscribeRestoresRedoOnFailure(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, proxy.eventListener.IsSubscriberCached(util.GetServiceCacheKey(util.GetGroupName("svc", "g"), "")))
 }
+
+// A response the server answered but did not accept (IsSuccess()==false)
+// arrives as (response, nil) from the rpc client, not as a transport error.
+// It must be treated exactly like a failure: surface an error and restore
+// the redo entry, otherwise the server keeps pushing a subscription the
+// client no longer tracks and reconnect never re-subscribes.
+func TestUnsubscribeRestoresRedoOnUnsuccessfulResponse(t *testing.T) {
+	proxy, _ := newTestProxy()
+	proxy.eventListener.CacheSubscriberForRedo(util.GetGroupName("svc", "g"), "")
+	proxy.send = func(r rpc_request.IRequest) (rpc_response.IResponse, error) {
+		return &rpc_response.SubscribeServiceResponse{
+			Response: &rpc_response.Response{Success: false, ResultCode: 500, Message: "server rejected"},
+		}, nil
+	}
+
+	err := proxy.Unsubscribe("svc", "g", "")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "server rejected")
+	assert.True(t, proxy.eventListener.IsSubscriberCached(util.GetServiceCacheKey(util.GetGroupName("svc", "g"), "")))
+}

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
@@ -329,3 +329,21 @@ func TestConcurrentRegisterAndDeregisterDoesNotDeadlock(t *testing.T) {
 		t.Fatal("timed out waiting for concurrent register/deregister to finish - possible deadlock on redoMu")
 	}
 }
+
+// TestUnsubscribeRestoresRedoOnFailure verifies that when the server-side
+// unsubscribe request fails, the redo cache entry is restored so a later
+// reconnect keeps re-subscribing instead of silently dropping the
+// subscription (the server only stops pushing once an unsubscribe actually
+// succeeds).
+func TestUnsubscribeRestoresRedoOnFailure(t *testing.T) {
+	proxy, _ := newTestProxy()
+	proxy.eventListener.CacheSubscriberForRedo(util.GetGroupName("svc", "g"), "")
+	proxy.send = func(r rpc_request.IRequest) (rpc_response.IResponse, error) {
+		return nil, errors.New("boom")
+	}
+
+	err := proxy.Unsubscribe("svc", "g", "")
+
+	assert.Error(t, err)
+	assert.True(t, proxy.eventListener.IsSubscriberCached(util.GetServiceCacheKey(util.GetGroupName("svc", "g"), "")))
+}

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
@@ -1,40 +1,331 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package naming_grpc
 
-import "github.com/nacos-group/nacos-sdk-go/v3/model"
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
 
-type MockNamingGrpc struct {
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/clients/naming_client/naming_proxy"
+	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
+	"github.com/nacos-group/nacos-sdk-go/v3/common/remote/rpc/rpc_request"
+	"github.com/nacos-group/nacos-sdk-go/v3/common/remote/rpc/rpc_response"
+	"github.com/nacos-group/nacos-sdk-go/v3/model"
+	"github.com/nacos-group/nacos-sdk-go/v3/util"
+)
+
+// newTestProxy builds a bare NamingGrpcProxy with a stubbed send function so
+// tests can assert on the exact request sequence without a live rpc client.
+func newTestProxy() (*NamingGrpcProxy, *[]rpc_request.IRequest) {
+	var sent []rpc_request.IRequest
+	proxy := &NamingGrpcProxy{clientConfig: constant.ClientConfig{NamespaceId: "ns"}}
+	proxy.eventListener = NewConnectionEventListener(proxy)
+	proxy.send = func(r rpc_request.IRequest) (rpc_response.IResponse, error) {
+		sent = append(sent, r)
+		return &rpc_response.InstanceResponse{Response: &rpc_response.Response{Success: true, ResultCode: 200}}, nil
+	}
+	return proxy, &sent
 }
 
-func (m *MockNamingGrpc) RegisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
-	return true, nil
+func TestRegisterInstanceKeepsSingleShape(t *testing.T) {
+	proxy, sent := newTestProxy()
+	instanceA := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	instanceB := model.Instance{Ip: "2.2.2.2", Port: 9090}
+
+	ok, err := proxy.RegisterInstance("svc", "group", instanceA)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Len(t, *sent, 1)
+	req, isInstanceReq := (*sent)[0].(*rpc_request.InstanceRequest)
+	assert.True(t, isInstanceReq)
+	assert.Equal(t, "registerInstance", req.Type)
+	assert.Equal(t, instanceA, req.Instance)
+
+	// A second RegisterInstance on the same service must NOT be upgraded to a
+	// batch request: it still sends a plain InstanceRequest and overwrites the
+	// single-shape redo cache.
+	ok, err = proxy.RegisterInstance("svc", "group", instanceB)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Len(t, *sent, 2)
+	req2, isInstanceReq := (*sent)[1].(*rpc_request.InstanceRequest)
+	assert.True(t, isInstanceReq)
+	assert.Equal(t, "registerInstance", req2.Type)
+	assert.Equal(t, instanceB, req2.Instance)
+
+	_, isBatch := proxy.eventListener.GetBatchInstancesForRedo("svc", "group")
+	assert.False(t, isBatch)
+	cached, ok := proxy.eventListener.registeredInstanceCached.Get(util.GetGroupName("svc", "group"))
+	assert.True(t, ok)
+	assert.Equal(t, instanceB, cached)
 }
 
-func (m *MockNamingGrpc) BatchRegisterInstance(serviceName string, groupName string, instances []model.Instance) (bool, error) {
-	return true, nil
+func TestDeregisterKnownBatchMemberRepublishesRetained(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	b := model.Instance{Ip: "2.2.2.2", Port: 8081}
+	c := model.Instance{Ip: "3.3.3.3", Port: 8082}
+
+	_, err := proxy.BatchRegisterInstance("svc", "group", []model.Instance{a, b, c})
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	ok, err := proxy.DeregisterInstance("svc", "group", b)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Len(t, *sent, 1)
+	req, isBatchReq := (*sent)[0].(*rpc_request.BatchInstanceRequest)
+	assert.True(t, isBatchReq)
+	assert.Equal(t, "batchRegisterInstance", req.Type)
+	assert.Equal(t, []model.Instance{a, c}, req.Instances)
+
+	for _, r := range *sent {
+		_, isPlain := r.(*rpc_request.InstanceRequest)
+		assert.False(t, isPlain, "no plain deregisterInstance request should be sent for a batch member")
+	}
+
+	retained, isBatch := proxy.eventListener.GetBatchInstancesForRedo("svc", "group")
+	assert.True(t, isBatch)
+	assert.Equal(t, []model.Instance{a, c}, retained)
 }
 
-func (m *MockNamingGrpc) DeregisterInstance(serviceName string, groupName string, instance model.Instance) (bool, error) {
-	return true, nil
+func TestDeregisterUnknownBatchMemberRepublishesSameSet(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	b := model.Instance{Ip: "2.2.2.2", Port: 8081}
+	unknown := model.Instance{Ip: "9.9.9.9", Port: 9999}
+
+	_, err := proxy.BatchRegisterInstance("svc", "group", []model.Instance{a, b})
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	ok, err := proxy.DeregisterInstance("svc", "group", unknown)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Len(t, *sent, 1)
+	req, isBatchReq := (*sent)[0].(*rpc_request.BatchInstanceRequest)
+	assert.True(t, isBatchReq)
+	assert.Equal(t, []model.Instance{a, b}, req.Instances)
+
+	retained, isBatch := proxy.eventListener.GetBatchInstancesForRedo("svc", "group")
+	assert.True(t, isBatch)
+	assert.Equal(t, []model.Instance{a, b}, retained)
 }
 
-func (m *MockNamingGrpc) GetServiceList(pageNo uint32, pageSize uint32, groupName string, selector *model.ExpressionSelector) (model.ServiceList, error) {
-	return model.ServiceList{Doms: []string{""}}, nil
+func TestDeregisterLastBatchMemberSendsEmptyNonNilBatch(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+
+	_, err := proxy.BatchRegisterInstance("svc", "group", []model.Instance{a})
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	ok, err := proxy.DeregisterInstance("svc", "group", a)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Len(t, *sent, 1)
+	req, isBatchReq := (*sent)[0].(*rpc_request.BatchInstanceRequest)
+	assert.True(t, isBatchReq)
+	assert.NotNil(t, req.Instances)
+	assert.Len(t, req.Instances, 0)
+	assert.True(t, strings.Contains(req.GetBody(req), `"instances":[]`),
+		"expected empty-but-non-nil instances array in wire body, got: %s", req.GetBody(req))
+
+	retained, isBatch := proxy.eventListener.GetBatchInstancesForRedo("svc", "group")
+	assert.True(t, isBatch)
+	assert.Len(t, retained, 0)
 }
 
-func (m *MockNamingGrpc) ServerHealthy() bool {
-	return true
+func TestDeregisterSingleShapeSendsPlainDeregister(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+
+	_, err := proxy.RegisterInstance("svc", "group", a)
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	ok, err := proxy.DeregisterInstance("svc", "group", a)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Len(t, *sent, 1)
+	req, isPlain := (*sent)[0].(*rpc_request.InstanceRequest)
+	assert.True(t, isPlain)
+	assert.Equal(t, "deregisterInstance", req.Type)
+
+	_, cached := proxy.eventListener.registeredInstanceCached.Get(util.GetGroupName("svc", "group"))
+	assert.False(t, cached)
+
+	// A service that was never registered also gets a plain deregister
+	// (Java parity: there is no redo data to consult, so it falls through
+	// the same single-shape path).
+	*sent = (*sent)[:0]
+	ok, err = proxy.DeregisterInstance("never-registered", "group", a)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Len(t, *sent, 1)
+	req2, isPlain := (*sent)[0].(*rpc_request.InstanceRequest)
+	assert.True(t, isPlain)
+	assert.Equal(t, "deregisterInstance", req2.Type)
 }
 
-func (m *MockNamingGrpc) QueryInstancesOfService(serviceName, groupName, clusters string, udpPort int, healthyOnly bool) (*model.Service, error) {
-	return &model.Service{}, nil
+func TestRedoReplayPreservesShape(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProxy := naming_proxy.NewMockINamingProxy(ctrl)
+	evListener := NewConnectionEventListener(mockProxy)
+
+	single := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	batch := []model.Instance{
+		{Ip: "2.2.2.2", Port: 8081},
+		{Ip: "3.3.3.3", Port: 8082},
+	}
+
+	evListener.CacheInstanceForRedo("svc-single", "group", single)
+	evListener.CacheInstancesForRedo("svc-batch", "group", batch)
+
+	mockProxy.EXPECT().RegisterInstance("svc-single", "group", single).Return(true, nil)
+	mockProxy.EXPECT().BatchRegisterInstance("svc-batch", "group", batch).Return(true, nil)
+
+	evListener.redoRegisterEachService()
 }
 
-func (m *MockNamingGrpc) Subscribe(serviceName, groupName, clusters string) (model.Service, error) {
-	return model.Service{}, nil
+// TestDeregisterAfterShapeTransitionTakesBatchPath drives the redo cache
+// through single -> batch shape (RegisterInstance(A) then
+// BatchRegisterInstance([A,B])) and asserts that deregistering A afterwards
+// takes the batch republish path, not the plain-deregister path: DeregisterInstance
+// consults the CURRENT redo shape (checked under redoMu), not whichever shape
+// happened to be cached when the service was first touched.
+func TestDeregisterAfterShapeTransitionTakesBatchPath(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	b := model.Instance{Ip: "2.2.2.2", Port: 8081}
+
+	_, err := proxy.RegisterInstance("svc", "group", a)
+	assert.NoError(t, err)
+	_, err = proxy.BatchRegisterInstance("svc", "group", []model.Instance{a, b})
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	ok, err := proxy.DeregisterInstance("svc", "group", a)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Len(t, *sent, 1)
+	req, isBatchReq := (*sent)[0].(*rpc_request.BatchInstanceRequest)
+	assert.True(t, isBatchReq, "deregister after a single->batch shape transition must take the batch path")
+	assert.Equal(t, []model.Instance{b}, req.Instances)
+
+	for _, r := range *sent {
+		_, isPlain := r.(*rpc_request.InstanceRequest)
+		assert.False(t, isPlain, "no plain deregisterInstance request should be sent once the service is batch-shaped")
+	}
 }
 
-func (m *MockNamingGrpc) Unsubscribe(serviceName, groupName, clusters string) error {
-	return nil
+// TestDeregisterSingleShapePropagatesSendError verifies error propagation on
+// the single-shape path and documents a deliberate Java-parity ordering: the
+// redo entry is removed BEFORE the send is attempted (mirrors Java's
+// deregisterServiceForEphemeral, which drops the redo data first and lets the
+// send fail independently) - so even when send fails, the client no longer
+// believes it owns a redo entry for this instance.
+func TestDeregisterSingleShapePropagatesSendError(t *testing.T) {
+	proxy, _ := newTestProxy()
+	sendErr := errors.New("boom")
+	proxy.send = func(r rpc_request.IRequest) (rpc_response.IResponse, error) {
+		return nil, sendErr
+	}
+
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	proxy.eventListener.CacheInstanceForRedo("svc", "group", a)
+
+	ok, err := proxy.DeregisterInstance("svc", "group", a)
+	assert.False(t, ok)
+	assert.Equal(t, sendErr, err)
+
+	// Deliberate Java-parity ordering: the redo entry is already gone even
+	// though the send failed.
+	_, cached := proxy.eventListener.registeredInstanceCached.Get(util.GetGroupName("svc", "group"))
+	assert.False(t, cached, "redo entry must be removed before the send is attempted, regardless of send outcome")
 }
 
-func (m *MockNamingGrpc) CloseClient() {}
+// TestConcurrentRegisterAndDeregisterDoesNotDeadlock hammers RegisterInstance/
+// BatchRegisterInstance against DeregisterInstance on the same service from
+// two goroutines. It intentionally asserts nothing about which shape wins -
+// only that redoMu (now guarding all three entry points, not just the batch
+// path) never self-deadlocks and the run finishes promptly. Run with -race to
+// let the race detector confirm the redo cache and the recorder are never
+// touched unsynchronized.
+func TestConcurrentRegisterAndDeregisterDoesNotDeadlock(t *testing.T) {
+	proxy := &NamingGrpcProxy{clientConfig: constant.ClientConfig{NamespaceId: "ns"}}
+	proxy.eventListener = NewConnectionEventListener(proxy)
+
+	var mu sync.Mutex
+	var sent []rpc_request.IRequest
+	recordSend := func(r rpc_request.IRequest) (rpc_response.IResponse, error) {
+		mu.Lock()
+		sent = append(sent, r)
+		mu.Unlock()
+		return &rpc_response.InstanceResponse{Response: &rpc_response.Response{Success: true, ResultCode: 200}}, nil
+	}
+	proxy.send = recordSend
+
+	const iterations = 200
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	b := model.Instance{Ip: "2.2.2.2", Port: 8081}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if i%2 == 0 {
+					_, _ = proxy.RegisterInstance("svc", "group", a)
+				} else {
+					_, _ = proxy.BatchRegisterInstance("svc", "group", []model.Instance{a, b})
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_, _ = proxy.DeregisterInstance("svc", "group", a)
+			}
+		}()
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		// success: no deadlock within the guard timeout. The -race flag does
+		// the real synchronization checking; this only guards against a hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for concurrent register/deregister to finish - possible deadlock on redoMu")
+	}
+}

--- a/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
+++ b/clients/naming_client/naming_grpc/naming_grpc_proxy_test.go
@@ -368,3 +368,63 @@ func TestUnsubscribeRestoresRedoOnUnsuccessfulResponse(t *testing.T) {
 	assert.Contains(t, err.Error(), "server rejected")
 	assert.True(t, proxy.eventListener.IsSubscriberCached(util.GetServiceCacheKey(util.GetGroupName("svc", "g"), "")))
 }
+
+// The proto wire carries ports as int32 while the public API exposes uint64:
+// an unchecked conversion would silently truncate 2^32+80 to 80 and make an
+// invalid register/deregister operate on a different, valid endpoint (the
+// legacy JSON wire sent the original value and let the server reject it).
+// Ports must therefore be rejected client-side before any redo-cache
+// mutation or request send.
+func TestRegisterInstanceRejectsOutOfRangePort(t *testing.T) {
+	proxy, sent := newTestProxy()
+	bad := model.Instance{Ip: "1.1.1.1", Port: 1<<32 + 80}
+
+	ok, err := proxy.RegisterInstance("svc", "group", bad)
+
+	assert.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "port")
+	assert.Empty(t, *sent, "no request may be sent for an invalid port")
+	_, cached := proxy.eventListener.registeredInstanceCached.Get(util.GetGroupName("svc", "group"))
+	assert.False(t, cached, "redo cache must stay untouched")
+}
+
+func TestBatchRegisterInstanceRejectsOutOfRangePort(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	seed := []model.Instance{a}
+	_, err := proxy.BatchRegisterInstance("svc", "group", seed)
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	bad := []model.Instance{a, {Ip: "2.2.2.2", Port: 1<<32 + 80}}
+	ok, err := proxy.BatchRegisterInstance("svc", "group", bad)
+
+	assert.Error(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, *sent)
+	retained, isBatch := proxy.eventListener.GetBatchInstancesForRedo("svc", "group")
+	assert.True(t, isBatch)
+	assert.Equal(t, seed, retained, "redo cache must keep the previous valid set")
+}
+
+func TestDeregisterInstanceRejectsOutOfRangePort(t *testing.T) {
+	proxy, sent := newTestProxy()
+	a := model.Instance{Ip: "1.1.1.1", Port: 8080}
+	b := model.Instance{Ip: "2.2.2.2", Port: 8081}
+	_, err := proxy.BatchRegisterInstance("svc", "group", []model.Instance{a, b})
+	assert.NoError(t, err)
+	*sent = (*sent)[:0]
+
+	// 2^32+8080 truncates to 8080 as int32 — without validation this would
+	// republish the batch minus instance a's neighbor at the truncated port.
+	bad := model.Instance{Ip: "1.1.1.1", Port: 1<<32 + 8080}
+	ok, err := proxy.DeregisterInstance("svc", "group", bad)
+
+	assert.Error(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, *sent)
+	retained, isBatch := proxy.eventListener.GetBatchInstancesForRedo("svc", "group")
+	assert.True(t, isBatch)
+	assert.Equal(t, []model.Instance{a, b}, retained)
+}

--- a/common/remote/rpc/proto_dispatch.go
+++ b/common/remote/rpc/proto_dispatch.go
@@ -124,7 +124,7 @@ func adaptBaseResponse(resultCode, errorCode int32, message, requestId string, b
 // wins over fail-fast here.
 func decodeProtoServerRequest(payload *nacos_grpc_service.Payload) (rpc_request.IRequest, bool) {
 	switch payload.GetMetadata().GetType() {
-	case "ConnectResetRequest", "ClientDetectionRequest":
+	case "ConnectResetRequest", "ClientDetectionRequest", "NotifySubscriberRequest":
 	default:
 		return nil, false
 	}
@@ -145,6 +145,13 @@ func decodeProtoServerRequest(payload *nacos_grpc_service.Payload) (rpc_request.
 		return req, true
 	case *common.ClientDetectionRequest:
 		req := &rpc_request.ClientDetectionRequest{InternalRequest: rpc_request.NewInternalRequest()}
+		req.RequestId = m.RequestId
+		return req, true
+	case *naming.NotifySubscriberRequest:
+		req := &rpc_request.NotifySubscriberRequest{
+			NamingRequest: rpc_request.NewNamingRequest(m.Namespace, m.ServiceName, m.GroupName),
+			ServiceInfo:   fromProtoServiceInfo(m.ServiceInfo),
+		}
 		req.RequestId = m.RequestId
 		return req, true
 	}

--- a/common/remote/rpc/proto_dispatch.go
+++ b/common/remote/rpc/proto_dispatch.go
@@ -21,6 +21,7 @@ import (
 
 	nacos_grpc_service "github.com/nacos-group/nacos-sdk-proto/go"
 	"github.com/nacos-group/nacos-sdk-proto/go/common"
+	"github.com/nacos-group/nacos-sdk-proto/go/naming"
 	"github.com/pkg/errors"
 
 	"github.com/nacos-group/nacos-sdk-go/v3/common/logger"
@@ -43,7 +44,9 @@ import (
 // cause.
 func decodeProtoResponse(payload *nacos_grpc_service.Payload) (rpc_response.IResponse, bool, error) {
 	switch payload.GetMetadata().GetType() {
-	case "HealthCheckResponse", "ServerCheckResponse", "ErrorResponse":
+	case "HealthCheckResponse", "ServerCheckResponse", "ErrorResponse",
+		"InstanceResponse", "BatchInstanceResponse", "QueryServiceResponse",
+		"SubscribeServiceResponse", "ServiceListResponse":
 	default:
 		return nil, false, nil
 	}
@@ -65,6 +68,26 @@ func decodeProtoResponse(payload *nacos_grpc_service.Payload) (rpc_response.IRes
 	case *common.ErrorResponse:
 		return &rpc_response.ErrorResponse{
 			Response: adaptBaseResponse(m.ResultCode, m.ErrorCode, m.Message, m.RequestId, body),
+		}, true, nil
+	case *naming.InstanceResponse:
+		return &rpc_response.InstanceResponse{Response: adaptBaseResponse(m.ResultCode, m.ErrorCode, m.Message, m.RequestId, body)}, true, nil
+	case *naming.BatchInstanceResponse:
+		return &rpc_response.BatchInstanceResponse{Response: adaptBaseResponse(m.ResultCode, m.ErrorCode, m.Message, m.RequestId, body)}, true, nil
+	case *naming.QueryServiceResponse:
+		return &rpc_response.QueryServiceResponse{
+			Response:    adaptBaseResponse(m.ResultCode, m.ErrorCode, m.Message, m.RequestId, body),
+			ServiceInfo: fromProtoServiceInfo(m.ServiceInfo),
+		}, true, nil
+	case *naming.SubscribeServiceResponse:
+		return &rpc_response.SubscribeServiceResponse{
+			Response:    adaptBaseResponse(m.ResultCode, m.ErrorCode, m.Message, m.RequestId, body),
+			ServiceInfo: fromProtoServiceInfo(m.ServiceInfo),
+		}, true, nil
+	case *naming.ServiceListResponse:
+		return &rpc_response.ServiceListResponse{
+			Response:     adaptBaseResponse(m.ResultCode, m.ErrorCode, m.Message, m.RequestId, body),
+			Count:        int(m.Count),
+			ServiceNames: m.ServiceNames,
 		}, true, nil
 	}
 	return nil, true, errors.Errorf("no proto adapter for migrated type %s", payload.GetMetadata().GetType())

--- a/common/remote/rpc/proto_dispatch_naming.go
+++ b/common/remote/rpc/proto_dispatch_naming.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"github.com/nacos-group/nacos-sdk-proto/go/naming"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/model"
+)
+
+// fromProtoInstance adapts a proto Instance to the legacy model struct.
+// The proto definition has no instanceHeartBeatInterval /
+// instanceHeartBeatTimeOut / ipDeleteTimeout fields (Java derives them
+// from metadata server-side); they stay zero here and nothing in the SDK
+// reads them on the subscribe/query paths.
+func fromProtoInstance(i *naming.Instance) model.Instance {
+	if i == nil {
+		return model.Instance{}
+	}
+	return model.Instance{
+		InstanceId:  i.InstanceId,
+		Ip:          i.Ip,
+		Port:        uint64(i.Port),
+		Weight:      i.Weight,
+		Healthy:     i.Healthy,
+		Enable:      i.Enabled,
+		Ephemeral:   i.Ephemeral,
+		ClusterName: i.ClusterName,
+		ServiceName: i.ServiceName,
+		Metadata:    i.Metadata,
+	}
+}
+
+// fromProtoServiceInfo adapts a proto ServiceInfo to model.Service. The
+// proto has no `valid` field (Java derived); every real server emits
+// valid=true on the legacy wire and the SDK never branches on it, so it
+// is pinned to true for wire compatibility.
+func fromProtoServiceInfo(si *naming.ServiceInfo) model.Service {
+	if si == nil {
+		return model.Service{}
+	}
+	hosts := make([]model.Instance, 0, len(si.Hosts))
+	for _, h := range si.Hosts {
+		hosts = append(hosts, fromProtoInstance(h))
+	}
+	return model.Service{
+		Name:                     si.Name,
+		GroupName:                si.GroupName,
+		Clusters:                 si.Clusters,
+		CacheMillis:              uint64(si.CacheMillis),
+		Hosts:                    hosts,
+		LastRefTime:              uint64(si.LastRefTime),
+		Checksum:                 si.Checksum,
+		AllIPs:                   si.AllIps,
+		ReachProtectionThreshold: si.ReachProtectionThreshold,
+		Valid:                    true,
+	}
+}

--- a/common/remote/rpc/proto_dispatch_naming.go
+++ b/common/remote/rpc/proto_dispatch_naming.go
@@ -17,16 +17,45 @@
 package rpc
 
 import (
+	"strconv"
+
 	"github.com/nacos-group/nacos-sdk-proto/go/naming"
 
+	"github.com/nacos-group/nacos-sdk-go/v3/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v3/model"
 )
 
+// Java defaults for the metadata-derived heartbeat lifecycle fields
+// (com.alibaba.nacos.api.common.Constants: DEFAULT_HEART_BEAT_INTERVAL /
+// DEFAULT_HEART_BEAT_TIMEOUT / DEFAULT_IP_DELETE_TIMEOUT, in milliseconds).
+const (
+	defaultHeartBeatInterval = 5000
+	defaultHeartBeatTimeout  = 15000
+	defaultIpDeleteTimeout   = 30000
+)
+
+// metadataIntWithDefault mirrors Java Instance#getMetaDataByKeyWithDefault:
+// only a plain non-negative integer string overrides the default; anything
+// missing or malformed falls back.
+func metadataIntWithDefault(metadata map[string]string, key string, def int) int {
+	v, ok := metadata[key]
+	if !ok || v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
 // fromProtoInstance adapts a proto Instance to the legacy model struct.
 // The proto definition has no instanceHeartBeatInterval /
-// instanceHeartBeatTimeOut / ipDeleteTimeout fields (Java derives them
-// from metadata server-side); they stay zero here and nothing in the SDK
-// reads them on the subscribe/query paths.
+// instanceHeartBeatTimeOut / ipDeleteTimeout fields: on the legacy JSON
+// wire the server serializes Java's metadata-derived getters, so the
+// adapter reproduces that derivation (preserved.* metadata keys with the
+// Java defaults) to keep the exported model.Instance fields identical
+// across both wire formats.
 func fromProtoInstance(i *naming.Instance) model.Instance {
 	if i == nil {
 		return model.Instance{}
@@ -42,6 +71,12 @@ func fromProtoInstance(i *naming.Instance) model.Instance {
 		ClusterName: i.ClusterName,
 		ServiceName: i.ServiceName,
 		Metadata:    i.Metadata,
+		InstanceHeartBeatInterval: metadataIntWithDefault(i.Metadata,
+			constant.HEART_BEAT_INTERVAL, defaultHeartBeatInterval),
+		InstanceHeartBeatTimeOut: metadataIntWithDefault(i.Metadata,
+			constant.HEART_BEAT_TIMEOUT, defaultHeartBeatTimeout),
+		IpDeleteTimeout: metadataIntWithDefault(i.Metadata,
+			constant.IP_DELETE_TIMEOUT, defaultIpDeleteTimeout),
 	}
 }
 

--- a/common/remote/rpc/proto_dispatch_naming.go
+++ b/common/remote/rpc/proto_dispatch_naming.go
@@ -35,15 +35,21 @@ const (
 )
 
 // metadataIntWithDefault mirrors Java Instance#getMetaDataByKeyWithDefault:
-// only a plain non-negative integer string overrides the default; anything
-// missing or malformed falls back.
+// only a digits-only string (Java's ^\d+$ check — no sign prefix, so "+1000"
+// and "-0" also fall back) overrides the default; anything missing or
+// malformed falls back.
 func metadataIntWithDefault(metadata map[string]string, key string, def int) int {
 	v, ok := metadata[key]
 	if !ok || v == "" {
 		return def
 	}
+	for _, c := range v {
+		if c < '0' || c > '9' {
+			return def
+		}
+	}
 	n, err := strconv.Atoi(v)
-	if err != nil || n < 0 {
+	if err != nil {
 		return def
 	}
 	return n

--- a/common/remote/rpc/proto_dispatch_naming_test.go
+++ b/common/remote/rpc/proto_dispatch_naming_test.go
@@ -186,3 +186,14 @@ func TestFromProtoInstanceHeartbeatInvalidMetadataFallsBack(t *testing.T) {
 	assert.Equal(t, 15000, inst.InstanceHeartBeatTimeOut)
 	assert.Equal(t, 30000, inst.IpDeleteTimeout)
 }
+
+// strconv.Atoi accepts sign prefixes ("+1000", "-0") that Java's ^\d+$
+// check rejects; both must fall back to the defaults for exact parity.
+func TestFromProtoInstanceHeartbeatSignPrefixedMetadataFallsBack(t *testing.T) {
+	inst := fromProtoInstance(&naming.Instance{Ip: "1.1.1.1", Port: 8080, Metadata: map[string]string{
+		"preserved.heart.beat.interval": "+1000",
+		"preserved.heart.beat.timeout":  "-0",
+	}})
+	assert.Equal(t, 5000, inst.InstanceHeartBeatInterval)
+	assert.Equal(t, 15000, inst.InstanceHeartBeatTimeOut)
+}

--- a/common/remote/rpc/proto_dispatch_naming_test.go
+++ b/common/remote/rpc/proto_dispatch_naming_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nacos-group/nacos-sdk-go/v3/common/remote/rpc/rpc_request"
 	"github.com/nacos-group/nacos-sdk-go/v3/common/remote/rpc/rpc_response"
 )
 
@@ -128,4 +129,25 @@ func TestDecodeProtoSubscribeServiceResponse(t *testing.T) {
 	assert.Equal(t, uint64(8001), s.ServiceInfo.Hosts[0].Port)
 	assert.True(t, s.ServiceInfo.Hosts[0].Enable)
 	assert.True(t, s.ServiceInfo.Valid)
+}
+
+func TestDecodeProtoNotifySubscriberRequest(t *testing.T) {
+	msg := &naming.NotifySubscriberRequest{
+		RequestId: "9", Namespace: "ns", ServiceName: "svc", GroupName: "g",
+		ServiceInfo: &naming.ServiceInfo{Name: "svc", GroupName: "g", LastRefTime: 123,
+			Hosts: []*naming.Instance{{Ip: "1.2.3.4", Port: 80, Enabled: true}}},
+	}
+	payload, err := payloadCodec.Encode("NotifySubscriberRequest", msg, nil, "127.0.0.1")
+	require.NoError(t, err)
+
+	req, decoded := decodeProtoServerRequest(payload)
+	require.True(t, decoded)
+	n, ok := req.(*rpc_request.NotifySubscriberRequest)
+	require.True(t, ok)
+	assert.Equal(t, "9", n.RequestId)
+	assert.Equal(t, "ns", n.Namespace)
+	assert.Equal(t, "svc", n.ServiceInfo.Name)
+	assert.Equal(t, uint64(123), n.ServiceInfo.LastRefTime)
+	require.Len(t, n.ServiceInfo.Hosts, 1)
+	assert.True(t, n.ServiceInfo.Hosts[0].Enable)
 }

--- a/common/remote/rpc/proto_dispatch_naming_test.go
+++ b/common/remote/rpc/proto_dispatch_naming_test.go
@@ -151,3 +151,38 @@ func TestDecodeProtoNotifySubscriberRequest(t *testing.T) {
 	require.Len(t, n.ServiceInfo.Hosts, 1)
 	assert.True(t, n.ServiceInfo.Hosts[0].Enable)
 }
+
+// The proto Instance has no heartbeat lifecycle fields; the legacy JSON wire
+// carried them because the server serializes Java's metadata-derived getters.
+// The adapter must reproduce that derivation so callers reading
+// model.Instance keep seeing the same values as on the JSON path.
+func TestFromProtoInstanceHeartbeatDefaults(t *testing.T) {
+	inst := fromProtoInstance(&naming.Instance{Ip: "1.1.1.1", Port: 8080})
+	assert.Equal(t, 5000, inst.InstanceHeartBeatInterval)
+	assert.Equal(t, 15000, inst.InstanceHeartBeatTimeOut)
+	assert.Equal(t, 30000, inst.IpDeleteTimeout)
+}
+
+func TestFromProtoInstanceHeartbeatMetadataOverrides(t *testing.T) {
+	inst := fromProtoInstance(&naming.Instance{Ip: "1.1.1.1", Port: 8080, Metadata: map[string]string{
+		"preserved.heart.beat.interval": "2000",
+		"preserved.heart.beat.timeout":  "6000",
+		"preserved.ip.delete.timeout":   "9000",
+	}})
+	assert.Equal(t, 2000, inst.InstanceHeartBeatInterval)
+	assert.Equal(t, 6000, inst.InstanceHeartBeatTimeOut)
+	assert.Equal(t, 9000, inst.IpDeleteTimeout)
+}
+
+// Java only accepts values matching ^\d+$ (getMetaDataByKeyWithDefault);
+// anything else falls back to the default.
+func TestFromProtoInstanceHeartbeatInvalidMetadataFallsBack(t *testing.T) {
+	inst := fromProtoInstance(&naming.Instance{Ip: "1.1.1.1", Port: 8080, Metadata: map[string]string{
+		"preserved.heart.beat.interval": "abc",
+		"preserved.heart.beat.timeout":  "-1",
+		"preserved.ip.delete.timeout":   "",
+	}})
+	assert.Equal(t, 5000, inst.InstanceHeartBeatInterval)
+	assert.Equal(t, 15000, inst.InstanceHeartBeatTimeOut)
+	assert.Equal(t, 30000, inst.IpDeleteTimeout)
+}

--- a/common/remote/rpc/proto_dispatch_naming_test.go
+++ b/common/remote/rpc/proto_dispatch_naming_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-proto/go/naming"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/common/remote/rpc/rpc_response"
+)
+
+func TestDecodeProtoQueryServiceResponse(t *testing.T) {
+	msg := &naming.QueryServiceResponse{
+		ResultCode: 200, RequestId: "7",
+		ServiceInfo: &naming.ServiceInfo{
+			Name: "svc", GroupName: "g", Clusters: "",
+			CacheMillis: 10000, LastRefTime: 1784787422078,
+			Hosts: []*naming.Instance{{
+				Ip: "192.168.100.1", Port: 8001, Weight: 10,
+				Healthy: true, Enabled: true, Ephemeral: true,
+				ClusterName: "DEFAULT", ServiceName: "g@@svc",
+				Metadata: map[string]string{},
+			}},
+		},
+	}
+	payload, err := payloadCodec.Encode("QueryServiceResponse", msg, nil, "127.0.0.1")
+	require.NoError(t, err)
+
+	resp, migrated, err := decodeProtoResponse(payload)
+	require.NoError(t, err)
+	require.True(t, migrated)
+	q, ok := resp.(*rpc_response.QueryServiceResponse)
+	require.True(t, ok)
+	assert.True(t, q.IsSuccess())
+	assert.Equal(t, "svc", q.ServiceInfo.Name)
+	assert.Equal(t, uint64(1784787422078), q.ServiceInfo.LastRefTime)
+	require.Len(t, q.ServiceInfo.Hosts, 1)
+	assert.Equal(t, uint64(8001), q.ServiceInfo.Hosts[0].Port)
+	assert.True(t, q.ServiceInfo.Hosts[0].Enable)
+	// proto ServiceInfo has no `valid` field; adapter pins it to true, which is
+	// what every real server emits on the legacy JSON wire.
+	assert.True(t, q.ServiceInfo.Valid)
+}
+
+func TestDecodeProtoServiceListResponse(t *testing.T) {
+	msg := &naming.ServiceListResponse{ResultCode: 200, Count: 3, ServiceNames: []string{"a", "b", "c"}}
+	payload, err := payloadCodec.Encode("ServiceListResponse", msg, nil, "127.0.0.1")
+	require.NoError(t, err)
+	resp, migrated, err := decodeProtoResponse(payload)
+	require.NoError(t, err)
+	require.True(t, migrated)
+	l := resp.(*rpc_response.ServiceListResponse)
+	assert.Equal(t, 3, l.Count)
+	assert.Equal(t, []string{"a", "b", "c"}, l.ServiceNames)
+}
+
+func TestDecodeProtoInstanceResponse(t *testing.T) {
+	msg := &naming.InstanceResponse{ResultCode: 200, RequestId: "1"}
+	payload, err := payloadCodec.Encode("InstanceResponse", msg, nil, "127.0.0.1")
+	require.NoError(t, err)
+
+	resp, migrated, err := decodeProtoResponse(payload)
+	require.NoError(t, err)
+	require.True(t, migrated)
+	i, ok := resp.(*rpc_response.InstanceResponse)
+	require.True(t, ok)
+	assert.True(t, i.IsSuccess())
+	assert.Equal(t, "1", i.RequestId)
+}
+
+func TestDecodeProtoBatchInstanceResponse(t *testing.T) {
+	msg := &naming.BatchInstanceResponse{ResultCode: 200, RequestId: "2"}
+	payload, err := payloadCodec.Encode("BatchInstanceResponse", msg, nil, "127.0.0.1")
+	require.NoError(t, err)
+
+	resp, migrated, err := decodeProtoResponse(payload)
+	require.NoError(t, err)
+	require.True(t, migrated)
+	b, ok := resp.(*rpc_response.BatchInstanceResponse)
+	require.True(t, ok)
+	assert.True(t, b.IsSuccess())
+	assert.Equal(t, "2", b.RequestId)
+}
+
+func TestDecodeProtoSubscribeServiceResponse(t *testing.T) {
+	msg := &naming.SubscribeServiceResponse{
+		ResultCode: 200, RequestId: "3",
+		ServiceInfo: &naming.ServiceInfo{
+			Name: "svc", GroupName: "g", Clusters: "",
+			CacheMillis: 10000, LastRefTime: 1784787422078,
+			Hosts: []*naming.Instance{{
+				Ip: "192.168.100.1", Port: 8001, Weight: 10,
+				Healthy: true, Enabled: true, Ephemeral: true,
+				ClusterName: "DEFAULT", ServiceName: "g@@svc",
+				Metadata: map[string]string{},
+			}},
+		},
+	}
+	payload, err := payloadCodec.Encode("SubscribeServiceResponse", msg, nil, "127.0.0.1")
+	require.NoError(t, err)
+
+	resp, migrated, err := decodeProtoResponse(payload)
+	require.NoError(t, err)
+	require.True(t, migrated)
+	s, ok := resp.(*rpc_response.SubscribeServiceResponse)
+	require.True(t, ok)
+	assert.True(t, s.IsSuccess())
+	assert.Equal(t, "svc", s.ServiceInfo.Name)
+	assert.Equal(t, uint64(1784787422078), s.ServiceInfo.LastRefTime)
+	require.Len(t, s.ServiceInfo.Hosts, 1)
+	assert.Equal(t, uint64(8001), s.ServiceInfo.Hosts[0].Port)
+	assert.True(t, s.ServiceInfo.Hosts[0].Enable)
+	assert.True(t, s.ServiceInfo.Valid)
+}

--- a/common/remote/rpc/proto_dispatch_test.go
+++ b/common/remote/rpc/proto_dispatch_test.go
@@ -91,8 +91,8 @@ func TestDecodeProtoServerRequestClientDetection(t *testing.T) {
 }
 
 func TestDecodeProtoServerRequestUnmigratedFallsThrough(t *testing.T) {
-	_, ok := decodeProtoServerRequest(protoPayload("NotifySubscriberRequest", `{}`))
-	assert.False(t, ok, "naming push stays on the legacy path until PR4")
+	_, ok := decodeProtoServerRequest(protoPayload("ConfigChangeNotifyRequest", `{}`))
+	assert.False(t, ok, "config push stays on the legacy path until PR5")
 }
 
 func TestDecodeProtoServerRequestBadJsonFallsBack(t *testing.T) {

--- a/common/remote/rpc/rpc_request/naming_request_proto.go
+++ b/common/remote/rpc/rpc_request/naming_request_proto.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc_request
+
+import (
+	"github.com/nacos-group/nacos-sdk-proto/go/naming"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/model"
+)
+
+// ProtoMessage implementations for naming requests. Field mapping is 1:1
+// with the legacy JSON body; `module` is a server-side derived field and
+// does not exist in the proto definitions (same rule as the PR2 batch).
+
+func toProtoInstance(i model.Instance) *naming.Instance {
+	return &naming.Instance{
+		InstanceId:  i.InstanceId,
+		Ip:          i.Ip,
+		Port:        int32(i.Port),
+		Weight:      i.Weight,
+		Healthy:     i.Healthy,
+		Enabled:     i.Enable,
+		Ephemeral:   i.Ephemeral,
+		ClusterName: i.ClusterName,
+		ServiceName: i.ServiceName,
+		Metadata:    i.Metadata,
+	}
+}
+
+func toProtoInstances(list []model.Instance) []*naming.Instance {
+	out := make([]*naming.Instance, 0, len(list))
+	for _, i := range list {
+		out = append(out, toProtoInstance(i))
+	}
+	return out
+}
+
+func (r *InstanceRequest) ProtoMessage() proto.Message {
+	return &naming.InstanceRequest{
+		RequestId:   r.RequestId,
+		Namespace:   r.Namespace,
+		ServiceName: r.ServiceName,
+		GroupName:   r.GroupName,
+		Type:        r.Type,
+		Instance:    toProtoInstance(r.Instance),
+	}
+}
+
+func (r *BatchInstanceRequest) ProtoMessage() proto.Message {
+	return &naming.BatchInstanceRequest{
+		RequestId:   r.RequestId,
+		Namespace:   r.Namespace,
+		ServiceName: r.ServiceName,
+		GroupName:   r.GroupName,
+		Type:        r.Type,
+		Instances:   toProtoInstances(r.Instances),
+	}
+}
+
+func (r *SubscribeServiceRequest) ProtoMessage() proto.Message {
+	return &naming.SubscribeServiceRequest{
+		RequestId:   r.RequestId,
+		Namespace:   r.Namespace,
+		ServiceName: r.ServiceName,
+		GroupName:   r.GroupName,
+		Subscribe:   r.Subscribe,
+		Clusters:    r.Clusters,
+	}
+}
+
+func (r *ServiceQueryRequest) ProtoMessage() proto.Message {
+	return &naming.ServiceQueryRequest{
+		RequestId:   r.RequestId,
+		Namespace:   r.Namespace,
+		ServiceName: r.ServiceName,
+		GroupName:   r.GroupName,
+		Cluster:     r.Cluster,
+		HealthyOnly: r.HealthyOnly,
+		UdpPort:     int32(r.UdpPort),
+	}
+}
+
+func (r *ServiceListRequest) ProtoMessage() proto.Message {
+	return &naming.ServiceListRequest{
+		RequestId:   r.RequestId,
+		Namespace:   r.Namespace,
+		ServiceName: r.ServiceName,
+		GroupName:   r.GroupName,
+		PageNo:      int32(r.PageNo),
+		PageSize:    int32(r.PageSize),
+		Selector:    r.Selector,
+	}
+}

--- a/common/remote/rpc/rpc_request/naming_request_proto_test.go
+++ b/common/remote/rpc/rpc_request/naming_request_proto_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc_request
+
+import (
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-proto/go/naming"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/model"
+)
+
+func sampleInstance() model.Instance {
+	return model.Instance{
+		InstanceId: "id-1", Ip: "192.168.100.1", Port: 8001, Weight: 10,
+		Healthy: true, Enable: true, Ephemeral: true,
+		ClusterName: "DEFAULT", ServiceName: "DEFAULT_GROUP@@svc",
+		Metadata: map[string]string{"idc": "test1"},
+	}
+}
+
+func TestInstanceRequestProtoMessage(t *testing.T) {
+	r := NewInstanceRequest("ns", "svc", "g", "registerInstance", sampleInstance())
+	r.RequestId = "42"
+	msg, ok := r.ProtoMessage().(*naming.InstanceRequest)
+	require.True(t, ok)
+	assert.Equal(t, "42", msg.RequestId)
+	assert.Equal(t, "ns", msg.Namespace)
+	assert.Equal(t, "svc", msg.ServiceName)
+	assert.Equal(t, "g", msg.GroupName)
+	assert.Equal(t, "registerInstance", msg.Type)
+	require.NotNil(t, msg.Instance)
+	assert.Equal(t, "192.168.100.1", msg.Instance.Ip)
+	assert.Equal(t, int32(8001), msg.Instance.Port)
+	assert.Equal(t, float64(10), msg.Instance.Weight)
+	assert.True(t, msg.Instance.Enabled)
+	assert.Equal(t, map[string]string{"idc": "test1"}, msg.Instance.Metadata)
+}
+
+func TestBatchInstanceRequestProtoMessage(t *testing.T) {
+	r := NewBatchInstanceRequest("ns", "svc", "g", "batchRegisterInstance",
+		[]model.Instance{sampleInstance(), sampleInstance()})
+	msg, ok := r.ProtoMessage().(*naming.BatchInstanceRequest)
+	require.True(t, ok)
+	assert.Len(t, msg.Instances, 2)
+	assert.Equal(t, "batchRegisterInstance", msg.Type)
+}
+
+func TestSubscribeServiceRequestProtoMessage(t *testing.T) {
+	r := NewSubscribeServiceRequest("ns", "svc", "g", "c1,c2", true)
+	msg, ok := r.ProtoMessage().(*naming.SubscribeServiceRequest)
+	require.True(t, ok)
+	assert.True(t, msg.Subscribe)
+	assert.Equal(t, "c1,c2", msg.Clusters)
+}
+
+func TestServiceQueryRequestProtoMessage(t *testing.T) {
+	r := NewServiceQueryRequest("ns", "svc", "g", "DEFAULT", true, 0)
+	msg, ok := r.ProtoMessage().(*naming.ServiceQueryRequest)
+	require.True(t, ok)
+	assert.Equal(t, "DEFAULT", msg.Cluster)
+	assert.True(t, msg.HealthyOnly)
+	assert.Equal(t, int32(0), msg.UdpPort)
+}
+
+func TestServiceListRequestProtoMessage(t *testing.T) {
+	r := NewServiceListRequest("ns", "", "g", 1, 100, "")
+	msg, ok := r.ProtoMessage().(*naming.ServiceListRequest)
+	require.True(t, ok)
+	assert.Equal(t, int32(1), msg.PageNo)
+	assert.Equal(t, int32(100), msg.PageSize)
+}

--- a/test/integration/naming_batch_lifecycle_test.go
+++ b/test/integration/naming_batch_lifecycle_test.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/clients"
+	"github.com/nacos-group/nacos-sdk-go/v3/model"
+	"github.com/nacos-group/nacos-sdk-go/v3/vo"
+)
+
+// hasPort reports whether hosts contains an instance bound to port.
+func hasPort(hosts []model.Instance, port uint64) bool {
+	for _, h := range hosts {
+		if h.Port == port {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIntegrationNamingBatchLifecycle walks a BatchRegisterInstance
+// publication through its whole life on a real server: shrinking via
+// DeregisterInstance republishes the retained set (batch shape, not the
+// single-instance path), an unknown member is a harmless no-op republish of
+// the same set, and removing every member clears the publication down to an
+// empty (but non-nil) batch rather than reverting to single shape. It then
+// restarts the server and confirms redo replays the batch shape it holds at
+// the time of the restart (#780), not just the most recent instance (#866).
+func TestIntegrationNamingBatchLifecycle(t *testing.T) {
+	client, err := clients.NewNamingClient(clientParam(t))
+	require.NoError(t, err, "create naming client")
+	defer client.CloseClient()
+
+	serviceName := fmt.Sprintf("it-batch-lifecycle-%d-%d", time.Now().UnixNano(), os.Getpid())
+	const ip = "10.0.0.40"
+	portA, portB, portC := uint64(19101), uint64(19102), uint64(19103)
+
+	batchRegister := func(ports ...uint64) {
+		t.Helper()
+		instances := make([]vo.RegisterInstanceParam, 0, len(ports))
+		for _, port := range ports {
+			instances = append(instances, vo.RegisterInstanceParam{
+				Ip:          ip,
+				Port:        port,
+				ServiceName: serviceName,
+				GroupName:   testGroup,
+				Weight:      1,
+				Enable:      true,
+				Healthy:     true,
+				Ephemeral:   true,
+			})
+		}
+		ok, err := client.BatchRegisterInstance(vo.BatchRegisterInstanceParam{
+			ServiceName: serviceName,
+			GroupName:   testGroup,
+			Instances:   instances,
+		})
+		require.NoError(t, err, "batch register instances %v", ports)
+		require.True(t, ok, "batch register instances %v should return true", ports)
+	}
+	deregister := func(port uint64) {
+		t.Helper()
+		ok, err := client.DeregisterInstance(vo.DeregisterInstanceParam{
+			Ip:          ip,
+			Port:        port,
+			ServiceName: serviceName,
+			GroupName:   testGroup,
+			Ephemeral:   true,
+		})
+		require.NoError(t, err, "deregister instance on port %d", port)
+		require.True(t, ok, "deregister instance on port %d should return true", port)
+	}
+	defer func() {
+		_, _ = client.BatchRegisterInstance(vo.BatchRegisterInstanceParam{
+			ServiceName: serviceName,
+			GroupName:   testGroup,
+			Instances:   []vo.RegisterInstanceParam{},
+		})
+	}()
+
+	// 1. BatchRegisterInstance(A,B,C) -> 3 hosts.
+	batchRegister(portA, portB, portC)
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		return err == nil && len(svc.Hosts) == 3
+	}, waitTimeout, waitInterval, "all 3 batch-registered instances should become discoverable")
+
+	// 2. DeregisterInstance(B) shrinks the batch via republish of the
+	// retained set {A, C} -> 2 hosts.
+	deregister(portB)
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		if err != nil || len(svc.Hosts) != 2 {
+			return false
+		}
+		return hasPort(svc.Hosts, portA) && hasPort(svc.Hosts, portC) && !hasPort(svc.Hosts, portB)
+	}, waitTimeout, waitInterval, "deregistering B should republish the retained {A, C} batch, leaving 2 hosts")
+
+	// 3. DeregisterInstance(unknown) is a no-op against the retained set: it
+	// still republishes {A, C} unchanged (ok=true), it must NOT be
+	// misinterpreted as clearing or shrinking anything further.
+	ok, err := client.DeregisterInstance(vo.DeregisterInstanceParam{
+		Ip:          "10.0.0.99",
+		Port:        29999,
+		ServiceName: serviceName,
+		GroupName:   testGroup,
+		Ephemeral:   true,
+	})
+	require.NoError(t, err, "deregister unknown instance")
+	require.True(t, ok, "deregister unknown instance should still return true (republish of the unchanged set)")
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		if err != nil || len(svc.Hosts) != 2 {
+			return false
+		}
+		return hasPort(svc.Hosts, portA) && hasPort(svc.Hosts, portC)
+	}, waitTimeout, waitInterval, "deregistering an unknown member should leave {A, C} untouched")
+
+	// 4. Deregistering the remaining members one at a time drains the batch
+	// to an empty (non-nil) republish, which clears the publication down to
+	// 0 hosts -- the #901-2 semantics: an empty batch is a legitimate,
+	// distinct state from "never registered" or "single shape", and must
+	// clear the server-side publication rather than leaving stale hosts.
+	deregister(portA)
+	deregister(portC)
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		return err == nil && len(svc.Hosts) == 0
+	}, waitTimeout, waitInterval, "draining every batch member should clear the publication to 0 hosts")
+
+	// 5. Re-publish a fresh batch {A, B} and, if a container name was
+	// provided, restart the server to replay #780: redo must resend the
+	// CURRENT batch shape it holds (a BatchInstanceRequest for {A, B}), not
+	// collapse to a single-instance shape or replay a stale prior batch.
+	batchRegister(portA, portB)
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		return err == nil && len(svc.Hosts) == 2 && hasPort(svc.Hosts, portA) && hasPort(svc.Hosts, portB)
+	}, waitTimeout, waitInterval, "re-published {A, B} batch should become discoverable before the restart")
+
+	container := os.Getenv("NACOS_CONTAINER_NAME")
+	if container == "" {
+		t.Log("NACOS_CONTAINER_NAME not set; skipping redo-replay-after-restart assertion")
+		return
+	}
+
+	out, err := exec.Command("docker", "restart", container).CombinedOutput()
+	require.NoError(t, err, "docker restart %s: %s", container, out)
+
+	// GetService/SelectInstances serve from the local subscription cache
+	// once a service has been seen once, so re-polling with the ORIGINAL
+	// client would only prove its in-memory cache still holds the
+	// pre-restart value, not that the server-side redo actually replayed
+	// anything. Verify with a brand-new client whose first successful read
+	// is a genuine subscribe/query against the server's post-redo state.
+	//
+	// 3.x restarts are noticeably slower than 2.x to become ready for new
+	// connections/subscriptions, hence the generous 180s budget below.
+	verifyClient, err := clients.NewNamingClient(clientParam(t))
+	require.NoError(t, err, "create verification naming client")
+	defer verifyClient.CloseClient()
+
+	deadline := time.Now().Add(180 * time.Second)
+	for time.Now().Before(deadline) {
+		svc, err := verifyClient.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		if err == nil && len(svc.Hosts) == 2 && hasPort(svc.Hosts, portA) && hasPort(svc.Hosts, portB) {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatal("redo did not replay the {A, B} batch shape within 180s after server restart")
+}
+
+// TestIntegrationNamingSingleInstanceReplaces documents #866's underlying
+// server behavior: the server keeps exactly one publication per
+// (connection, service) for the plain (non-batch) registerInstance call, so
+// a second RegisterInstance for the same service REPLACES the first rather
+// than adding to it. Callers that need several instances of one service
+// published from a single client must use BatchRegisterInstance instead.
+func TestIntegrationNamingSingleInstanceReplaces(t *testing.T) {
+	client, err := clients.NewNamingClient(clientParam(t))
+	require.NoError(t, err, "create naming client")
+	defer client.CloseClient()
+
+	serviceName := fmt.Sprintf("it-single-replace-%d-%d", time.Now().UnixNano(), os.Getpid())
+	const ip = "10.0.0.41"
+	portX, portY := uint64(19201), uint64(19202)
+
+	defer func() {
+		_, _ = client.DeregisterInstance(vo.DeregisterInstanceParam{
+			Ip: ip, Port: portY, ServiceName: serviceName, GroupName: testGroup, Ephemeral: true,
+		})
+	}()
+
+	registerOne := func(port uint64) {
+		t.Helper()
+		ok, err := client.RegisterInstance(vo.RegisterInstanceParam{
+			Ip:          ip,
+			Port:        port,
+			ServiceName: serviceName,
+			GroupName:   testGroup,
+			Weight:      1,
+			Enable:      true,
+			Healthy:     true,
+			Ephemeral:   true,
+		})
+		require.NoError(t, err, "register instance on port %d", port)
+		require.True(t, ok, "register instance on port %d should return true", port)
+	}
+
+	registerOne(portX)
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		return err == nil && len(svc.Hosts) == 1 && hasPort(svc.Hosts, portX)
+	}, waitTimeout, waitInterval, "X should become the sole discoverable instance")
+
+	registerOne(portY)
+	assert.Eventually(t, func() bool {
+		svc, err := client.GetService(vo.GetServiceParam{ServiceName: serviceName, GroupName: testGroup})
+		return err == nil && len(svc.Hosts) == 1 && hasPort(svc.Hosts, portY) && !hasPort(svc.Hosts, portX)
+	}, waitTimeout, waitInterval, "registering Y should replace X, leaving Y as the sole instance")
+}

--- a/test/integration/naming_subscribe_test.go
+++ b/test/integration/naming_subscribe_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nacos-group/nacos-sdk-go/v3/clients"
+	"github.com/nacos-group/nacos-sdk-go/v3/model"
+	"github.com/nacos-group/nacos-sdk-go/v3/vo"
+)
+
+// TestIntegrationNamingSubscribeRegression replays #865: a subscription
+// (with or without a cluster filter) must keep firing across a
+// register -> deregister -> re-register cycle, on both the unfiltered and
+// the cluster-filtered subscription path.
+func TestIntegrationNamingSubscribeRegression(t *testing.T) {
+	client, err := clients.NewNamingClient(clientParam(t))
+	require.NoError(t, err, "create naming client")
+	defer client.CloseClient()
+
+	suffix := fmt.Sprintf("%d-%d", time.Now().UnixNano(), os.Getpid())
+	serviceNoFilter := "it-sub-nofilter-" + suffix
+	serviceWithFilter := "it-sub-filter-" + suffix
+	const clusterName = "IT-CLUSTER"
+
+	var countNoFilter int64
+	var countWithFilter int64
+
+	callbackNoFilter := func(services []model.Instance, err error) {
+		atomic.AddInt64(&countNoFilter, 1)
+	}
+	callbackWithFilter := func(services []model.Instance, err error) {
+		atomic.AddInt64(&countWithFilter, 1)
+	}
+
+	paramNoFilter := &vo.SubscribeParam{
+		ServiceName:       serviceNoFilter,
+		GroupName:         testGroup,
+		SubscribeCallback: callbackNoFilter,
+	}
+	paramWithFilter := &vo.SubscribeParam{
+		ServiceName:       serviceWithFilter,
+		GroupName:         testGroup,
+		Clusters:          []string{clusterName},
+		SubscribeCallback: callbackWithFilter,
+	}
+
+	require.NoError(t, client.Subscribe(paramNoFilter), "subscribe without cluster filter")
+	require.NoError(t, client.Subscribe(paramWithFilter), "subscribe with cluster filter")
+	defer func() {
+		_ = client.Unsubscribe(paramNoFilter)
+		_ = client.Unsubscribe(paramWithFilter)
+	}()
+
+	const ipNoFilter = "10.0.0.30"
+	const ipWithFilter = "10.0.0.31"
+	const portNoFilter uint64 = 19001
+	const portWithFilter uint64 = 19002
+
+	register := func(svc, ip string, port uint64, cluster string) {
+		t.Helper()
+		ok, err := client.RegisterInstance(vo.RegisterInstanceParam{
+			Ip:          ip,
+			Port:        port,
+			ServiceName: svc,
+			GroupName:   testGroup,
+			ClusterName: cluster,
+			Weight:      1,
+			Enable:      true,
+			Healthy:     true,
+			Ephemeral:   true,
+		})
+		require.NoError(t, err, "register instance for %s", svc)
+		require.True(t, ok, "register instance for %s should return true", svc)
+	}
+	deregister := func(svc, ip string, port uint64, cluster string) {
+		t.Helper()
+		ok, err := client.DeregisterInstance(vo.DeregisterInstanceParam{
+			Ip:          ip,
+			Port:        port,
+			ServiceName: svc,
+			GroupName:   testGroup,
+			Cluster:     cluster,
+			Ephemeral:   true,
+		})
+		require.NoError(t, err, "deregister instance for %s", svc)
+		require.True(t, ok, "deregister instance for %s should return true", svc)
+	}
+
+	defer func() {
+		_, _ = client.DeregisterInstance(vo.DeregisterInstanceParam{
+			Ip: ipNoFilter, Port: portNoFilter, ServiceName: serviceNoFilter, GroupName: testGroup, Ephemeral: true,
+		})
+		_, _ = client.DeregisterInstance(vo.DeregisterInstanceParam{
+			Ip: ipWithFilter, Port: portWithFilter, ServiceName: serviceWithFilter, GroupName: testGroup,
+			Cluster: clusterName, Ephemeral: true,
+		})
+	}()
+
+	// Subscribe synchronously delivers an initial snapshot before it
+	// returns, so an absolute threshold like ">= 1 after register" is
+	// vacuous -- it's already satisfied by the snapshot before register()
+	// even runs, and ">= 2 after deregister" could equally be satisfied by
+	// two register fires alone. Capture a
+	// per-step baseline for each counter and require it to advance past
+	// that baseline, so each assertion is attributable to its own step and
+	// a regression that breaks only e.g. the deregister-notification path
+	// cannot hide behind the other steps' fires.
+
+	// register
+	baseNoFilter := atomic.LoadInt64(&countNoFilter)
+	baseWithFilter := atomic.LoadInt64(&countWithFilter)
+	register(serviceNoFilter, ipNoFilter, portNoFilter, "")
+	register(serviceWithFilter, ipWithFilter, portWithFilter, clusterName)
+
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&countNoFilter) > baseNoFilter },
+		waitTimeout, waitInterval, "unfiltered subscription should fire on register")
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&countWithFilter) > baseWithFilter },
+		waitTimeout, waitInterval, "cluster-filtered subscription should fire on register")
+
+	// deregister
+	baseNoFilter = atomic.LoadInt64(&countNoFilter)
+	baseWithFilter = atomic.LoadInt64(&countWithFilter)
+	deregister(serviceNoFilter, ipNoFilter, portNoFilter, "")
+	deregister(serviceWithFilter, ipWithFilter, portWithFilter, clusterName)
+
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&countNoFilter) > baseNoFilter },
+		waitTimeout, waitInterval, "unfiltered subscription should fire on deregister")
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&countWithFilter) > baseWithFilter },
+		waitTimeout, waitInterval, "cluster-filtered subscription should fire on deregister")
+
+	// re-register
+	baseNoFilter = atomic.LoadInt64(&countNoFilter)
+	baseWithFilter = atomic.LoadInt64(&countWithFilter)
+	register(serviceNoFilter, ipNoFilter, portNoFilter, "")
+	register(serviceWithFilter, ipWithFilter, portWithFilter, clusterName)
+
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&countNoFilter) > baseNoFilter },
+		waitTimeout, waitInterval, "unfiltered subscription should fire on re-register")
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&countWithFilter) > baseWithFilter },
+		waitTimeout, waitInterval, "cluster-filtered subscription should fire on re-register")
+}


### PR DESCRIPTION
## What is this PR for

Reworked per the round-1 review: scope is now **naming sdk-proto migration + Java-parity instance redo semantics + Unsubscribe fixes**. The transparent register-to-batch upgrade, the subscribe deduplication and FuzzyWatch have all been removed from this PR (disposition of every review point is mapped below).

### 1. Naming proto migration (3 commits, unchanged from round 1)

`InstanceRequest` / `BatchInstanceRequest` / `ServiceQueryRequest` / `SubscribeServiceRequest` / `ServiceListRequest` are encoded via sdk-proto with the legacy JSON fallback; naming responses and the `NotifySubscriberRequest` push are decoded through the PayloadCodec whitelists established in #897.

### 2. Java-parity instance redo semantics (replaces auto-batch)

`RegisterInstance` keeps its original single-request semantics — no client-side set, no transparent batch upgrade. Instead, the redo cache now preserves the **original request shape** (mirroring Java's `InstanceRedoData` / `BatchInstanceRedoData`):

- `DeregisterInstance` on a **batch-registered** service removes the first ip:port match from the retained list and republishes the remainder as a batch — unchanged set when the member is unknown, **empty batch when it was the last member** (this clears the publication; verified live on 2.5.2/3.2.0). It never falls through to a plain `deregisterInstance`. This mirrors `NamingGrpcClientProxy#batchDeregisterService` / `getRetainInstance`.
- `DeregisterInstance` on a single-shape (or never-registered) service sends a plain deregister, as before and as Java does.
- Reconnect redo replays each service in its original shape (single → `InstanceRequest`, batch → `BatchInstanceRequest`) — the #780 fix, now covered by unit + integration regression.
- Redo-cache mutations are serialized by a monitor mirroring Java's `synchronized(registeredInstances)`; the batch-deregister path holds it across the republish like Java does. Note for reviewers: this introduces a per-proxy serialization point that did not exist in the Go base (registrations may briefly block while a batch-deregister republish is in flight, bounded by the request timeout) — same trade-off as the Java client.

Probe findings that shaped this (all reproduced on 2.5.2 and 3.2.0):

| Scenario | Result |
|---|---|
| plain deregister (known or unknown member, any cluster value) against a **batch** publication | server-side no-op — republish is the only way to shrink a batch |
| plain deregister of an unknown instance against a **single** publication | no-op — does not remove the publication |
| `BatchInstanceRequest` with empty `[]` instances | clears the publication (both versions) |
| `BatchInstanceRequest` with JSON `null` instances (Go nil slice) | 3.2.0 rejects with server NPE — the SDK now guards with a non-nil empty slice |

For **#866** itself: sequential `RegisterInstance` calls replacing each other is server-side semantics (one publication per connection+service). Per the review decision this PR documents it (method comment + an integration test demonstrating the replace behavior) and points multi-instance publishers to `BatchRegisterInstance`.

### 3. Unsubscribe fixes (review item 7)

- Empty group is normalized to `DEFAULT_GROUP` (Subscribe already did; without this the callback registered under `DEFAULT_GROUP@@svc` was never found — pre-existing bug on v3.x-dev, verified against the base).
- On server-side unsubscribe failure both the local callback and the redo entry are restored, so pushes keep being handled and reconnect keeps re-subscribing until a successful retry.

### Compatibility notes (review item 10)

- No `INamingClient` additions or removals in this PR.
- Exported redo methods on `ConnectionEventListener` keep their base signatures (`CacheInstanceForRedo` / `CacheInstancesForRedo` / `RemoveInstanceForRedo`); one accessor added: `GetBatchInstancesForRedo`.
- Behavior changes: (a) `DeregisterInstance` against a batch-registered service now shrinks by republish instead of sending an ineffective plain deregister; (b) redo mutations are serialized as described above.

### Review round-1 disposition map

| Review item | Where |
|---|---|
| 1 auto-batch removal | this PR (section 2) |
| 2 batch redo semantics | this PR (section 2) |
| 3/5/6/8/9 FuzzyWatch | follow-up PR based on this branch, ready after this merges |
| 4 callback identity | dedupe reverted to base behavior here; explicit-handle API to be discussed on #655 |
| 7 Unsubscribe | this PR (section 3) |
| 10 race-fix split + compat notes | race fix → #903; notes above |

Note: this branch temporarily carries #903's commit (`e09b7ca`, patch-identical) because the `-race` integration job trips the pre-existing sort race without it; once #903 merges, a rebase drops it automatically.

## Testing

- Unit: `go test ./clients/... ./common/... -count=1 -race` green; new coverage for shape transitions, unknown-member republish, empty-batch wire body (`"instances":[]`), error propagation, and a `-race` register/deregister concurrency hammer.
- Integration (both live servers, `-count=1 -race`): batch lifecycle 3→2→unknown→0 hosts, container-restart redo shape restoration (#780), sequential-register replace semantics (#866), subscribe regression (#865 per-step deltas). Nacos 3.2.0: 20.8s; Nacos 2.5.2: 21.0s.

Fixes #780
Refs #866 #879 #900
