### PR TITLE
fix(naming): copy hosts before sorting in service change detection

### DIFF
--- a/clients/naming_client/naming_cache/service_info_holder.go
+++ b/clients/naming_client/naming_cache/service_info_holder.go
@@ -193,8 +193,13 @@ func isServiceInstanceChanged(oldService, newService model.Service) bool {
 		logger.Warnf("out of date data received, old-t: %v , new-t:  %v", oldRefTime, newRefTime)
 		return false
 	}
-	// sort instance list
-	oldInstance := oldService.Hosts
+	// sort instance list. oldService.Hosts shares its backing array with the
+	// model.Service value already stored in (and possibly concurrently read
+	// back out of) ServiceInfoMap, so it must be copied before an in-place
+	// sort -- sorting it directly races with any concurrent reader holding
+	// an earlier GetServiceInfo/GetService result over the same array.
+	oldInstance := make([]model.Instance, len(oldService.Hosts))
+	copy(oldInstance, oldService.Hosts)
 	newInstance := make([]model.Instance, len(newService.Hosts))
 	copy(newInstance, newService.Hosts)
 	sortInstance(oldInstance)


### PR DESCRIPTION
## What

Fixes a data race in `isServiceInstanceChanged` (`clients/naming_client/naming_cache/service_info_holder.go`), where the "old" instance list was sorted in place before being compared against the new one.

## The bug

`isServiceInstanceChanged` compares the previous and new instance lists for a service by sorting copies of both and comparing element-by-element. The "new" side was already copied before sorting (`newInstance := make(...); copy(newInstance, newService.Hosts)`), but the "old" side was not — it sorted `oldService.Hosts` directly:

```go
oldInstance := oldService.Hosts
...
sortInstance(oldInstance)
```

`oldService` is the `model.Service` value currently stored in `ServiceInfoMap`, and `oldService.Hosts` shares its backing array with that stored value — and with every snapshot previously handed out by `GetService`/`GetServiceInfo`. Sorting `oldInstance` in place therefore mutates memory that a concurrent reader (e.g. another goroutine holding an earlier `GetService` result) may be reading at the same time, which is a classic data race.

## The fix

Copy `oldService.Hosts` into a fresh slice before sorting it, mirroring the existing `newInstance` copy:

```go
oldInstance := make([]model.Instance, len(oldService.Hosts))
copy(oldInstance, oldService.Hosts)
```

## How it was found

While doing integration verification for #901 (the naming-module v3-parity PR), running the suite under `go test -race` reliably flagged this race once concurrent `GetService` calls overlapped with service-change processing.

## Test coverage

The scenario is exercised by the multi-instance integration test added alongside the broader naming-module work in #901 (`test/integration/naming_multi_instance_test.go`), which repeatedly calls `client.GetService` and asserts on the returned `Hosts` snapshots while instance updates are being processed in the background — i.e. concurrent readers over the same backing array that the in-place sort used to race with. That test lives on the #901 branch rather than this isolated one, since this PR only carries the standalone fix commit; here, `go test ./clients/naming_client/naming_cache/... -count=1 -race` passes cleanly with the fix applied.

## Why a separate PR

This fix was originally included in #901, but was split out into its own PR per review feedback there, since it's an independent, self-contained bug fix unrelated to the rest of that PR's naming-module changes.

Refs #901
